### PR TITLE
Add appropriate documentation comments to the parts of the Native nam…

### DIFF
--- a/src/Native/MiniAudioNative.cs
+++ b/src/Native/MiniAudioNative.cs
@@ -67,98 +67,258 @@ namespace MiniAudioEx.Native
     using ma_vfs_file = IntPtr;
     using ma_spinlock = UInt32;
 
+    /// <summary>
+    /// Provides P/Invoke bindings to the native miniaudio library.
+    /// All methods in this class are thin wrappers around <c>extern</c> DLL imports from the
+    /// native <c>miniaudioex</c> shared library. Each method corresponds to a C function in the
+    /// miniaudio public API.
+    /// </summary>
     public static class MiniAudioNative
     {
+        /// <summary>
+        /// The maximum number of audio channels supported.
+        /// </summary>
         public const int MA_MAX_CHANNELS = 254;
+        /// <summary>
+        /// The maximum length of a device name string, including the null terminator.
+        /// </summary>
         public const int MA_MAX_DEVICE_NAME_LENGTH = 255;
+        /// <summary>
+        /// The maximum number of log callbacks that can be registered with a single log instance.
+        /// </summary>
         public const int MA_MAX_LOG_CALLBACKS = 4;
+        /// <summary>
+        /// The maximum number of spatial audio listeners supported by the engine.
+        /// </summary>
         public const int MA_ENGINE_MAX_LISTENERS = 4;
+        /// <summary>
+        /// The maximum number of local buses supported by a node. Used internally for memory management and must never exceed MA_MAX_NODE_BUS_COUNT.
+        /// </summary>
         public const int MA_MAX_NODE_LOCAL_BUS_COUNT = 2;
+        /// <summary>
+        /// The maximum number of buses a node can have.
+        /// </summary>
         public const int MA_MAX_NODE_BUS_COUNT = 254;
+        /// <summary>
+        /// Indicates that the bus count for a node is unknown and must be determined on a per-node basis via the node configuration.
+        /// </summary>
         public const int MA_NODE_BUS_COUNT_UNKNOWN = 255;
 
         private const string LIB_MINIAUDIO_EX = "miniaudioex";
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Retrieves the number of bytes per sample for the given audio format.
+        /// </summary>
+        /// <param name="format">The audio format to query.</param>
+        /// <returns>The number of bytes per sample for the specified format.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_uint32 ma_get_bytes_per_sample(ma_format format);
 
+        /// <summary>
+        /// Managed helper that calculates the number of bytes per frame by multiplying bytes per sample with the channel count.
+        /// </summary>
+        /// <param name="format">The audio format.</param>
+        /// <param name="channels">The number of channels.</param>
+        /// <returns>The number of bytes per frame for the given format and channel count.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ma_uint32 ma_get_bytes_per_frame(ma_format format, ma_uint32 channels) 
         { 
             return ma_get_bytes_per_sample(format) * channels; 
         }
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Allocates memory for a structure of the given allocation type.
+        /// </summary>
+        /// <param name="type">The allocation type that determines the size of the allocated memory block.</param>
+        /// <returns>A pointer to the allocated memory, or IntPtr.Zero if allocation fails.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr ma_allocate_type(ma_allocation_type type);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Allocates a block of memory of the specified size.
+        /// </summary>
+        /// <param name="size">The number of bytes to allocate.</param>
+        /// <returns>A pointer to the allocated memory, or IntPtr.Zero if allocation fails.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr ma_allocate(size_t size);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Frees memory previously allocated with ma_allocate_type.
+        /// </summary>
+        /// <param name="pData">A pointer to the memory block to free.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_deallocate_type(IntPtr pData);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Retrieves the size in bytes of the structure associated with the given allocation type.
+        /// </summary>
+        /// <param name="type">The allocation type to query.</param>
+        /// <returns>The size in bytes of the structure for the specified allocation type.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern size_t ma_get_size_of_type(ma_allocation_type type);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Initializes and returns an engine configuration with default settings.
+        /// </summary>
+        /// <returns>A default-initialized engine configuration structure.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_engine_config ma_engine_config_init();
 
         // ma_device
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Initializes a device configuration structure with default settings for the given device type.
+        /// </summary>
+        /// <param name="deviceType">The type of device (playback, capture, duplex, or loopback).</param>
+        /// <returns>A default-initialized device configuration.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_device_config ma_device_config_init(ma_device_type deviceType);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Initializes a device with the given context and configuration.
+        /// </summary>
+        /// <param name="pContext">A pointer to the initialized context that will own the device.</param>
+        /// <param name="pConfig">The device configuration.</param>
+        /// <param name="pDevice">A pointer to the uninitialized device structure to initialize.</param>
+        /// <returns>MA_SUCCESS if the device was initialized successfully, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_device_init(ma_context_ptr pContext, ref ma_device_config pConfig, ma_device_ptr pDevice);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Uninitializes a previously initialized device, releasing its resources.
+        /// </summary>
+        /// <param name="pDevice">A pointer to the device to uninitialize.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_device_uninit(ma_device_ptr pDevice);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Retrieves the context that owns this device.
+        /// </summary>
+        /// <param name="pDevice">A pointer to the device.</param>
+        /// <returns>A pointer to the context that owns the device.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_context_ptr ma_device_get_context(ma_device_ptr pDevice);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Starts the device, beginning audio processing.
+        /// </summary>
+        /// <param name="pDevice">A pointer to the device to start.</param>
+        /// <returns>MA_SUCCESS if the device was started successfully, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_device_start(ma_device_ptr pDevice);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Stops the device, halting audio processing.
+        /// </summary>
+        /// <param name="pDevice">A pointer to the device to stop.</param>
+        /// <returns>MA_SUCCESS if the device was stopped successfully, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_device_stop(ma_device_ptr pDevice);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Queries whether the device has been started.
+        /// </summary>
+        /// <param name="pDevice">A pointer to the device to query.</param>
+        /// <returns>MA_TRUE if the device is started, otherwise MA_FALSE.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_bool32 ma_device_is_started(ma_device_ptr pDevice);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Retrieves the current state of the device.
+        /// </summary>
+        /// <param name="pDevice">A pointer to the device to query.</param>
+        /// <returns>The current device state (started, stopped, starting, or stopping).</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_device_state ma_device_get_state(ma_device_ptr pDevice);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Sets the master volume of the device on a linear scale.
+        /// </summary>
+        /// <param name="pDevice">A pointer to the device.</param>
+        /// <param name="volume">The linear volume level, where 1.0 is the default.</param>
+        /// <returns>MA_SUCCESS if the volume was set, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_device_set_master_volume(ma_device_ptr pDevice, float volume);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Retrieves the current master volume of the device on a linear scale.
+        /// </summary>
+        /// <param name="pDevice">A pointer to the device.</param>
+        /// <param name="pVolume">Receives the current linear volume level.</param>
+        /// <returns>MA_SUCCESS if the volume was retrieved, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_device_get_master_volume(ma_device_ptr pDevice, out float pVolume);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Sets the master volume of the device in decibels.
+        /// </summary>
+        /// <param name="pDevice">A pointer to the device.</param>
+        /// <param name="gainDB">The volume level in decibels, where 0 is the default.</param>
+        /// <returns>MA_SUCCESS if the volume was set, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_device_set_master_volume_db(ma_device_ptr pDevice, float gainDB);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Retrieves the current master volume of the device in decibels.
+        /// </summary>
+        /// <param name="pDevice">A pointer to the device.</param>
+        /// <param name="pGainDB">Receives the current volume level in decibels.</param>
+        /// <returns>MA_SUCCESS if the volume was retrieved, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_device_get_master_volume_db(ma_device_ptr pDevice, out float pGainDB);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Manually processes backend-level data for the device, used when the device is not started automatically.
+        /// </summary>
+        /// <param name="pDevice">A pointer to the device.</param>
+        /// <param name="pOutput">A pointer to the output buffer that will receive the processed audio data.</param>
+        /// <param name="pInput">A pointer to the input buffer containing incoming audio data.</param>
+        /// <param name="frameCount">The number of audio frames to process.</param>
+        /// <returns>MA_SUCCESS if the data callback was handled, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_device_handle_backend_data_callback(ma_device_ptr pDevice, IntPtr pOutput, IntPtr pInput, ma_uint32 frameCount);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Retrieves a pointer to the device's resampling configuration.
+        /// </summary>
+        /// <param name="pDevice">A pointer to the device.</param>
+        /// <returns>A pointer to the resampling data of the device.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_device_resampling_ptr ma_device_get_resampling(ma_device_ptr pDevice);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Retrieves a pointer to the device's playback configuration and state.
+        /// </summary>
+        /// <param name="pDevice">A pointer to the device.</param>
+        /// <returns>A pointer to the playback data of the device.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_device_playback_ptr ma_device_get_playback(ma_device_ptr pDevice);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Retrieves a pointer to the device's capture configuration and state.
+        /// </summary>
+        /// <param name="pDevice">A pointer to the device.</param>
+        /// <returns>A pointer to the capture data of the device.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_device_capture_ptr ma_device_get_capture(ma_device_ptr pDevice);
 
         // ma_context
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Initializes and returns a context configuration structure with default settings.
+        /// </summary>
+        /// <returns>A default-initialized context configuration.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_context_config ma_context_config_init();
 
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe ma_result ma_context_init(ma_backend* backends, ma_uint32 backendCount, ma_context_config* pConfig, ma_context_ptr pContext);
 
+        /// <summary>
+        /// Managed helper that initializes a context with the specified backend array and custom configuration. Calls the native ma_context_init function.
+        /// </summary>
+        /// <param name="backends">An array of backends to try, in order of preference. Pass null or an empty array to use default backends.</param>
+        /// <param name="config">The context configuration settings.</param>
+        /// <param name="pContext">A pointer to the uninitialized context structure.</param>
+        /// <returns>MA_SUCCESS if the context was initialized successfully, otherwise an error code.</returns>
         public static unsafe ma_result ma_context_init(ma_backend[] backends, ref ma_context_config config, ma_context_ptr pContext)
         {
             fixed (ma_context_config* pConfig = &config)
@@ -177,6 +337,12 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Managed helper that initializes a context with the specified backend array using default configuration. Calls the native ma_context_init function with a null config pointer.
+        /// </summary>
+        /// <param name="backends">An array of backends to try, in order of preference. Pass null or an empty array to use default backends.</param>
+        /// <param name="pContext">A pointer to the uninitialized context structure.</param>
+        /// <returns>MA_SUCCESS if the context was initialized successfully, otherwise an error code.</returns>
         public static unsafe ma_result ma_context_init(ma_backend[] backends, ma_context_ptr pContext)
         {
             if (backends?.Length > 0)
@@ -192,18 +358,39 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Uninitializes a previously initialized context, releasing its resources.
+        /// </summary>
+        /// <param name="pContext">A pointer to the context to uninitialize.</param>
+        /// <returns>MA_SUCCESS if the context was uninitialized successfully, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_context_uninit(ma_context_ptr pContext);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Returns the size in bytes of the context structure.
+        /// </summary>
+        /// <returns>The size of the context structure in bytes.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern size_t ma_context_sizeof();
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Retrieves a pointer to the log instance associated with the context.
+        /// </summary>
+        /// <param name="pContext">A pointer to the context.</param>
+        /// <returns>A pointer to the log instance of the context.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_log_ptr ma_context_get_log(ma_context_ptr pContext);
 
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern ma_result ma_context_enumerate_devices(ma_context_ptr pContext, IntPtr callback, IntPtr pUserData);
 
+        /// <summary>
+        /// Managed helper that enumerates available audio devices, invoking the provided callback for each device found.
+        /// </summary>
+        /// <param name="pContext">A pointer to the context.</param>
+        /// <param name="callback">The delegate to invoke for each enumerated device.</param>
+        /// <param name="pUserData">A user data pointer passed to each callback invocation.</param>
+        /// <returns>MA_SUCCESS if enumeration was successful, otherwise an error code.</returns>
         public static ma_result ma_context_enumerate_devices(ma_context_ptr pContext, ma_enum_devices_callback_proc callback, IntPtr pUserData)
         {
             return ma_context_enumerate_devices(pContext, MarshalHelper.GetFunctionPointerForDelegate(callback), pUserData);
@@ -212,6 +399,14 @@ namespace MiniAudioEx.Native
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe ma_result ma_context_get_devices(ma_context_ptr pContext, ma_device_info** ppPlaybackDeviceInfos, ma_uint32* pPlaybackDeviceCount, ma_device_info** ppCaptureDeviceInfos, ma_uint32* pCaptureDeviceCount);
 
+        /// <summary>
+        /// Managed helper that retrieves arrays of playback and capture device information for the given context.
+        /// Copies the native device info structures into managed arrays for safe use in .NET code.
+        /// </summary>
+        /// <param name="pContext">A pointer to the context.</param>
+        /// <param name="ppPlaybackDeviceInfos">Receives an array of playback device information, or null if none are available.</param>
+        /// <param name="ppCaptureDeviceInfos">Receives an array of capture device information, or null if none are available.</param>
+        /// <returns>MA_SUCCESS if devices were retrieved successfully, otherwise an error code.</returns>
         public static unsafe ma_result ma_context_get_devices(ma_context_ptr pContext, out ma_device_info[] ppPlaybackDeviceInfos, out ma_device_info[] ppCaptureDeviceInfos)
         {
             ppPlaybackDeviceInfos = null;
@@ -249,19 +444,47 @@ namespace MiniAudioEx.Native
             return result;
         }
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Retrieves detailed information about a specific audio device.
+        /// </summary>
+        /// <param name="pContext">A pointer to the context.</param>
+        /// <param name="deviceType">The type of device to query (playback or capture).</param>
+        /// <param name="pDeviceID">A pointer to the device ID to retrieve information for.</param>
+        /// <param name="pDeviceInfo">Receives the device information structure.</param>
+        /// <returns>MA_SUCCESS if the device info was retrieved, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_context_get_device_info(ma_context_ptr pContext, ma_device_type deviceType, ma_device_id_ptr pDeviceID, out ma_device_info pDeviceInfo);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Queries whether loopback audio capture is supported by the current backend.
+        /// </summary>
+        /// <param name="pContext">A pointer to the context.</param>
+        /// <returns>MA_TRUE if loopback is supported, otherwise MA_FALSE.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_bool32 ma_context_is_loopback_supported(ma_context_ptr pContext);
 
         // ma_engine
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Uninitializes a previously initialized engine, releasing its resources.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the engine to uninitialize.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_engine_uninit(ma_engine_ptr pEngine);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Initializes an engine with the given configuration.
+        /// </summary>
+        /// <param name="pConfig">The engine configuration, typically obtained from ma_engine_config_init.</param>
+        /// <param name="pEngine">A pointer to the uninitialized engine structure.</param>
+        /// <returns>MA_SUCCESS if the engine was initialized successfully, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_engine_init(ref ma_engine_config pConfig, ma_engine_ptr pEngine);
 
+        /// <summary>
+        /// Managed helper that initializes an engine with default configuration settings.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the uninitialized engine structure.</param>
+        /// <returns>MA_SUCCESS if the engine was initialized successfully, otherwise an error code.</returns>
         public static ma_result ma_engine_init(ma_engine_ptr pEngine)
         {
             ma_engine_config config = ma_engine_config_init();
@@ -271,6 +494,14 @@ namespace MiniAudioEx.Native
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe ma_result ma_engine_read_pcm_frames(ma_engine_ptr pEngine, IntPtr pFramesOut, ma_uint64 frameCount, ma_uint64* pFramesRead);
 
+        /// <summary>
+        /// Managed helper that reads PCM frames from the engine's output, reporting the number of frames actually read.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the engine.</param>
+        /// <param name="pFramesOut">A pointer to the output buffer that will receive the PCM frame data.</param>
+        /// <param name="frameCount">The number of frames to read.</param>
+        /// <param name="framesRead">Receives the number of frames actually read.</param>
+        /// <returns>MA_SUCCESS if frames were read, otherwise an error code.</returns>
         public static unsafe ma_result ma_engine_read_pcm_frames(ma_engine_ptr pEngine, IntPtr pFramesOut, ma_uint64 frameCount, ref ma_uint64 framesRead)
         {
             fixed (ma_uint64* pFramesRead = &framesRead)
@@ -279,516 +510,1216 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Managed helper that reads PCM frames from the engine's output without tracking the number of frames read.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the engine.</param>
+        /// <param name="pFramesOut">A pointer to the output buffer that will receive the PCM frame data.</param>
+        /// <param name="frameCount">The number of frames to read.</param>
+        /// <returns>MA_SUCCESS if frames were read, otherwise an error code.</returns>
         public static unsafe ma_result ma_engine_read_pcm_frames(ma_engine_ptr pEngine, IntPtr pFramesOut, ma_uint64 frameCount)
         {
             return ma_engine_read_pcm_frames(pEngine, pFramesOut, frameCount, null);
         }
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Retrieves a pointer to the engine's internal node graph.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the engine.</param>
+        /// <returns>A pointer to the node graph of the engine.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_node_graph_ptr ma_engine_get_node_graph(ma_engine_ptr pEngine);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Retrieves a pointer to the engine's resource manager.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the engine.</param>
+        /// <returns>A pointer to the resource manager of the engine.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_resource_manager_ptr ma_engine_get_resource_manager(ma_engine_ptr pEngine);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Retrieves a pointer to the audio device bound to the engine.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the engine.</param>
+        /// <returns>A pointer to the device owned by the engine.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_device_ptr ma_engine_get_device(ma_engine_ptr pEngine);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Retrieves a pointer to the engine's log instance.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the engine.</param>
+        /// <returns>A pointer to the log instance of the engine.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_log_ptr ma_engine_get_log(ma_engine_ptr pEngine);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Retrieves a pointer to the engine's endpoint node, which is the final node in the audio graph.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the engine.</param>
+        /// <returns>A pointer to the endpoint node of the engine's node graph.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_node_ptr ma_engine_get_endpoint(ma_engine_ptr pEngine);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Retrieves the current global time of the engine in PCM frames.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the engine.</param>
+        /// <returns>The current global time in PCM frames.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_uint64 ma_engine_get_time_in_pcm_frames(ma_engine_ptr pEngine);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Retrieves the current global time of the engine in milliseconds.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the engine.</param>
+        /// <returns>The current global time in milliseconds.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_uint64 ma_engine_get_time_in_milliseconds(ma_engine_ptr pEngine);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Sets the current global time of the engine in PCM frames.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the engine.</param>
+        /// <param name="globalTime">The new global time in PCM frames.</param>
+        /// <returns>MA_SUCCESS if the time was set, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_engine_set_time_in_pcm_frames(ma_engine_ptr pEngine, ma_uint64 globalTime);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Sets the current global time of the engine in milliseconds.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the engine.</param>
+        /// <param name="globalTime">The new global time in milliseconds.</param>
+        /// <returns>MA_SUCCESS if the time was set, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_engine_set_time_in_milliseconds(ma_engine_ptr pEngine, ma_uint64 globalTime);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Retrieves the number of audio channels configured for the engine.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the engine.</param>
+        /// <returns>The number of channels.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_uint32 ma_engine_get_channels(ma_engine_ptr pEngine);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Retrieves the sample rate configured for the engine.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the engine.</param>
+        /// <returns>The sample rate in Hz.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_uint32 ma_engine_get_sample_rate(ma_engine_ptr pEngine);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Starts the engine's audio device, beginning audio processing.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the engine to start.</param>
+        /// <returns>MA_SUCCESS if the engine was started, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_engine_start(ma_engine_ptr pEngine);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Stops the engine's audio device, halting audio processing.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the engine to stop.</param>
+        /// <returns>MA_SUCCESS if the engine was stopped, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_engine_stop(ma_engine_ptr pEngine);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Sets the master volume of the engine on a linear scale.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the engine.</param>
+        /// <param name="volume">The linear volume level, where 1.0 is the default.</param>
+        /// <returns>MA_SUCCESS if the volume was set, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_engine_set_volume(ma_engine_ptr pEngine, float volume);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Retrieves the current master volume of the engine on a linear scale.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the engine.</param>
+        /// <returns>The current linear volume level.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_engine_get_volume(ma_engine_ptr pEngine);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Sets the master volume of the engine in decibels.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the engine.</param>
+        /// <param name="gainDB">The volume level in decibels, where 0 is the default.</param>
+        /// <returns>MA_SUCCESS if the gain was set, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_engine_set_gain_db(ma_engine_ptr pEngine, float gainDB);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Retrieves the current master volume of the engine in decibels.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the engine.</param>
+        /// <returns>The current volume level in decibels.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_engine_get_gain_db(ma_engine_ptr pEngine);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Retrieves the number of spatial audio listeners active in the engine.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the engine.</param>
+        /// <returns>The number of active listeners.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_uint32 ma_engine_get_listener_count(ma_engine_ptr pEngine);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Finds the index of the listener closest to the specified absolute position.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the engine.</param>
+        /// <param name="absolutePosX">The X coordinate of the position to test.</param>
+        /// <param name="absolutePosY">The Y coordinate of the position to test.</param>
+        /// <param name="absolutePosZ">The Z coordinate of the position to test.</param>
+        /// <returns>The index of the closest listener.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_uint32 ma_engine_find_closest_listener(ma_engine_ptr pEngine, float absolutePosX, float absolutePosY, float absolutePosZ);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Sets the position of a spatial audio listener in 3D space.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the engine.</param>
+        /// <param name="listenerIndex">The index of the listener to modify.</param>
+        /// <param name="x">The X coordinate of the listener position.</param>
+        /// <param name="y">The Y coordinate of the listener position.</param>
+        /// <param name="z">The Z coordinate of the listener position.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_engine_listener_set_position(ma_engine_ptr pEngine, ma_uint32 listenerIndex, float x, float y, float z);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Retrieves the position of a spatial audio listener.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the engine.</param>
+        /// <param name="listenerIndex">The index of the listener to query.</param>
+        /// <returns>The position of the listener as a 3D vector.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_vec3f ma_engine_listener_get_position(ma_engine_ptr pEngine, ma_uint32 listenerIndex);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Sets the direction vector of a spatial audio listener.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the engine.</param>
+        /// <param name="listenerIndex">The index of the listener to modify.</param>
+        /// <param name="x">The X component of the direction vector.</param>
+        /// <param name="y">The Y component of the direction vector.</param>
+        /// <param name="z">The Z component of the direction vector.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_engine_listener_set_direction(ma_engine_ptr pEngine, ma_uint32 listenerIndex, float x, float y, float z);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Retrieves the direction vector of a spatial audio listener.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the engine.</param>
+        /// <param name="listenerIndex">The index of the listener to query.</param>
+        /// <returns>The direction vector of the listener.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_vec3f ma_engine_listener_get_direction(ma_engine_ptr pEngine, ma_uint32 listenerIndex);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Sets the velocity vector of a spatial audio listener for Doppler effect calculation.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the engine.</param>
+        /// <param name="listenerIndex">The index of the listener to modify.</param>
+        /// <param name="x">The X component of the velocity vector.</param>
+        /// <param name="y">The Y component of the velocity vector.</param>
+        /// <param name="z">The Z component of the velocity vector.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_engine_listener_set_velocity(ma_engine_ptr pEngine, ma_uint32 listenerIndex, float x, float y, float z);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Retrieves the velocity vector of a spatial audio listener.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the engine.</param>
+        /// <param name="listenerIndex">The index of the listener to query.</param>
+        /// <returns>The velocity vector of the listener.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_vec3f ma_engine_listener_get_velocity(ma_engine_ptr pEngine, ma_uint32 listenerIndex);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Sets the cone parameters for a spatial audio listener, defining directional attenuation.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the engine.</param>
+        /// <param name="listenerIndex">The index of the listener to modify.</param>
+        /// <param name="innerAngleInRadians">The inner angle of the cone in radians, where gain is at full volume.</param>
+        /// <param name="outerAngleInRadians">The outer angle of the cone in radians, where gain transitions to outerGain.</param>
+        /// <param name="outerGain">The gain applied outside the outer cone angle.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_engine_listener_set_cone(ma_engine_ptr pEngine, ma_uint32 listenerIndex, float innerAngleInRadians, float outerAngleInRadians, float outerGain);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Retrieves the cone parameters for a spatial audio listener.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the engine.</param>
+        /// <param name="listenerIndex">The index of the listener to query.</param>
+        /// <param name="pInnerAngleInRadians">Receives the inner cone angle in radians.</param>
+        /// <param name="pOuterAngleInRadians">Receives the outer cone angle in radians.</param>
+        /// <param name="pOuterGain">Receives the gain applied outside the outer cone.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_engine_listener_get_cone(ma_engine_ptr pEngine, ma_uint32 listenerIndex, out float pInnerAngleInRadians, out float pOuterAngleInRadians, out float pOuterGain);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Sets the world-up vector for a spatial audio listener.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the engine.</param>
+        /// <param name="listenerIndex">The index of the listener to modify.</param>
+        /// <param name="x">The X component of the world-up vector.</param>
+        /// <param name="y">The Y component of the world-up vector.</param>
+        /// <param name="z">The Z component of the world-up vector.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_engine_listener_set_world_up(ma_engine_ptr pEngine, ma_uint32 listenerIndex, float x, float y, float z);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Retrieves the world-up vector for a spatial audio listener.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the engine.</param>
+        /// <param name="listenerIndex">The index of the listener to query.</param>
+        /// <returns>The world-up vector of the listener.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_vec3f ma_engine_listener_get_world_up(ma_engine_ptr pEngine, ma_uint32 listenerIndex);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Enables or disables a spatial audio listener.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the engine.</param>
+        /// <param name="listenerIndex">The index of the listener to modify.</param>
+        /// <param name="isEnabled">MA_TRUE to enable the listener, MA_FALSE to disable it.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_engine_listener_set_enabled(ma_engine_ptr pEngine, ma_uint32 listenerIndex, ma_bool32 isEnabled);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Queries whether a spatial audio listener is enabled.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the engine.</param>
+        /// <param name="listenerIndex">The index of the listener to query.</param>
+        /// <returns>MA_TRUE if the listener is enabled, otherwise MA_FALSE.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_bool32 ma_engine_listener_is_enabled(ma_engine_ptr pEngine, ma_uint32 listenerIndex);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Plays a sound file from the given path, attaching it to a specific node and input bus.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the engine.</param>
+        /// <param name="pFilePath">The file path of the audio file to play.</param>
+        /// <param name="pNode">A pointer to the node to attach the sound to.</param>
+        /// <param name="nodeInputBusIndex">The input bus index on the target node to attach the sound to.</param>
+        /// <returns>MA_SUCCESS if playback started, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_engine_play_sound_ex(ma_engine_ptr pEngine, string pFilePath, ma_node_ptr pNode, ma_uint32 nodeInputBusIndex);
 
+        /// <summary>
+        /// Native function wrapper for the miniaudioex C API. Plays a sound file in a fire-and-forget manner. The returned sound is attached to the engine's endpoint and begins playing immediately.
+        /// </summary>
+        /// <param name="pEngine">A pointer to the engine.</param>
+        /// <param name="pFilePath">The file path of the audio file to play.</param>
+        /// <param name="pGroup">Optional sound group to attach the sound to. Pass IntPtr.Zero for no group.</param>
+        /// <returns>MA_SUCCESS if the sound was created and set to play, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_engine_play_sound(ma_engine_ptr pEngine, string pFilePath, ma_sound_group_ptr pGroup);   /* Fire and forget. */
 
         // ma_sound
+        /// <summary>Initializes a sound from a file path for playback with the given engine.</summary>
+        /// <param name="pEngine">The engine to use for playback.</param>
+        /// <param name="pFilePath">The file path of the audio file to load.</param>
+        /// <param name="flags">Flags controlling how the sound is loaded and played (e.g. MA_SOUND_FLAG_DECODE, MA_SOUND_FLAG_STREAM, MA_SOUND_FLAG_ASYNC).</param>
+        /// <param name="pGroup">Optional sound group to attach the sound to. Pass IntPtr.Zero for no group.</param>
+        /// <param name="pDoneFence">Optional fence that is signalled when async loading completes. Pass IntPtr.Zero if not needed.</param>
+        /// <param name="pSound">Pointer to the sound object to initialize.</param>
+        /// <returns><see cref="ma_result.success"/> on success, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_sound_init_from_file(ma_engine_ptr pEngine, string pFilePath, ma_sound_flags flags, ma_sound_group_ptr pGroup, ma_fence_ptr pDoneFence, ma_sound_ptr pSound);
 
+        /// <summary>Initializes a sound from a wide-char file path for playback with the given engine.</summary>
+        /// <param name="pEngine">The engine to use for playback.</param>
+        /// <param name="pFilePath">The wide-char file path of the audio file to load.</param>
+        /// <param name="flags">Flags controlling how the sound is loaded and played.</param>
+        /// <param name="pGroup">Optional sound group to attach the sound to. Pass IntPtr.Zero for no group.</param>
+        /// <param name="pDoneFence">Optional fence that is signalled when async loading completes. Pass IntPtr.Zero if not needed.</param>
+        /// <param name="pSound">Pointer to the sound object to initialize.</param>
+        /// <returns><see cref="ma_result.success"/> on success, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_sound_init_from_file_w(ma_engine_ptr pEngine, [MarshalAs(UnmanagedType.LPWStr)] string pFilePath, ma_sound_flags flags, ma_sound_group_ptr pGroup, ma_fence_ptr pDoneFence, ma_sound_ptr pSound);
 
+        /// <summary>Initializes a sound from in-memory audio data for playback with the given engine.</summary>
+        /// <param name="pEngine">The engine to use for playback.</param>
+        /// <param name="pData">Pointer to the memory buffer containing the encoded audio data.</param>
+        /// <param name="dataSize">The size of the memory buffer in bytes.</param>
+        /// <param name="flags">Flags controlling how the sound is loaded and played.</param>
+        /// <param name="pGroup">Optional sound group to attach the sound to. Pass IntPtr.Zero for no group.</param>
+        /// <param name="pDoneFence">Optional fence that is signalled when async loading completes. Pass IntPtr.Zero if not needed.</param>
+        /// <param name="pSound">Pointer to the sound object to initialize.</param>
+        /// <returns><see cref="ma_result.success"/> on success, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_sound_init_from_memory(ma_engine_ptr pEngine, IntPtr pData, ma_uint64 dataSize, ma_sound_flags flags, ma_sound_group_ptr pGroup, ma_fence_ptr pDoneFence, ma_sound_ptr pSound);
 
+        /// <summary>Initializes a sound from a procedural data source callback for playback with the given engine.</summary>
+        /// <param name="pEngine">The engine to use for playback.</param>
+        /// <param name="pConfig">Configuration for the procedural data source including format, channels, sample rate and callback.</param>
+        /// <param name="flags">Flags controlling how the sound is loaded and played.</param>
+        /// <param name="pGroup">Optional sound group to attach the sound to. Pass IntPtr.Zero for no group.</param>
+        /// <param name="pDoneFence">Optional fence that is signalled when async loading completes. Pass IntPtr.Zero if not needed.</param>
+        /// <param name="pSound">Pointer to the sound object to initialize.</param>
+        /// <returns><see cref="ma_result.success"/> on success, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_sound_init_from_callback(ma_engine_ptr pEngine, ref ma_procedural_data_source_config pConfig, ma_sound_flags flags, ma_sound_group_ptr pGroup, ma_fence_ptr pDoneFence, ma_sound_ptr pSound);
 
+        /// <summary>Initializes a sound as a copy of an existing sound.</summary>
+        /// <param name="pEngine">The engine to use for playback.</param>
+        /// <param name="pExistingSound">Pointer to the existing sound to copy.</param>
+        /// <param name="flags">Flags controlling how the sound is loaded and played.</param>
+        /// <param name="pGroup">Optional sound group to attach the sound to. Pass IntPtr.Zero for no group.</param>
+        /// <param name="pSound">Pointer to the sound object to initialize.</param>
+        /// <returns><see cref="ma_result.success"/> on success, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_sound_init_copy(ma_engine_ptr pEngine, ma_sound_ptr pExistingSound, ma_sound_flags flags, ma_sound_group_ptr pGroup, ma_sound_ptr pSound);
 
+        /// <summary>Initializes a sound from an existing data source for playback with the given engine.</summary>
+        /// <param name="pEngine">The engine to use for playback.</param>
+        /// <param name="pDataSource">Pointer to an existing data source.</param>
+        /// <param name="flags">Flags controlling how the sound is loaded and played.</param>
+        /// <param name="pGroup">Optional sound group to attach the sound to. Pass IntPtr.Zero for no group.</param>
+        /// <param name="pSound">Pointer to the sound object to initialize.</param>
+        /// <returns><see cref="ma_result.success"/> on success, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_sound_init_from_data_source(ma_engine_ptr pEngine, ma_data_source_ptr pDataSource, ma_sound_flags flags, ma_sound_group_ptr pGroup, ma_sound_ptr pSound);
 
+        /// <summary>Initializes a sound with full configuration for maximum flexibility.</summary>
+        /// <param name="pEngine">The engine to use for playback.</param>
+        /// <param name="pConfig">Full sound configuration including data source, end callback, and spatialization settings.</param>
+        /// <param name="pSound">Pointer to the sound object to initialize.</param>
+        /// <returns><see cref="ma_result.success"/> on success, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_sound_init_ex(ma_engine_ptr pEngine, ref ma_sound_config pConfig, ma_sound_ptr pSound);
 
+        /// <summary>Uninitializes and frees resources associated with a sound.</summary>
+        /// <param name="pSound">Pointer to the sound to uninitialize.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_uninit(ma_sound_ptr pSound);
 
+        /// <summary>Retrieves the engine that owns this sound.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <returns>Pointer to the engine that owns the sound.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_engine_ptr ma_sound_get_engine(ma_sound_ptr pSound);
 
+        /// <summary>Retrieves the underlying data source of the sound.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <returns>Pointer to the data source associated with the sound.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_data_source_ptr ma_sound_get_data_source(ma_sound_ptr pSound);
 
+        /// <summary>Starts playback of the sound.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <returns><see cref="ma_result.success"/> on success, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_sound_start(ma_sound_ptr pSound);
 
+        /// <summary>Stops playback of the sound.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <returns><see cref="ma_result.success"/> on success, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_sound_stop(ma_sound_ptr pSound);
 
+        /// <summary>Stops playback with a fade-out over the specified number of PCM frames. Overwrites any scheduled stop and fade.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="fadeLengthInFrames">The fade-out duration in PCM frames.</param>
+        /// <returns><see cref="ma_result.success"/> on success, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_sound_stop_with_fade_in_pcm_frames(ma_sound_ptr pSound, ma_uint64 fadeLengthInFrames);     /* Will overwrite any scheduled stop and fade. */
 
+        /// <summary>Stops playback with a fade-out over the specified duration in milliseconds. Overwrites any scheduled stop and fade.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="fadeLengthInFrames">The fade-out duration in milliseconds.</param>
+        /// <returns><see cref="ma_result.success"/> on success, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_sound_stop_with_fade_in_milliseconds(ma_sound_ptr pSound, ma_uint64 fadeLengthInFrames);   /* Will overwrite any scheduled stop and fade. */
 
+        /// <summary>Sets the volume of the sound. A value of 1.0 is the default volume.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="volume">The volume level, where 0.0 is silence and 1.0 is default.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_set_volume(ma_sound_ptr pSound, float volume);
 
+        /// <summary>Retrieves the current volume of the sound.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <returns>The current volume level.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_sound_get_volume(ma_sound_ptr pSound);
 
+        /// <summary>Sets the pan of the sound. -1.0 is left, 0.0 is center, 1.0 is right.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="pan">The pan value, typically between -1.0 (left) and 1.0 (right).</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_set_pan(ma_sound_ptr pSound, float pan);
 
+        /// <summary>Retrieves the current pan of the sound.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <returns>The current pan value, where -1.0 is left, 0.0 is center, and 1.0 is right.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_sound_get_pan(ma_sound_ptr pSound);
 
+        /// <summary>Sets the pan mode of the sound.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="panMode">The panning mode (e.g. balance or pan).</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_set_pan_mode(ma_sound_ptr pSound, ma_pan_mode panMode);
 
+        /// <summary>Retrieves the current pan mode of the sound.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <returns>The current pan mode.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_pan_mode ma_sound_get_pan_mode(ma_sound_ptr pSound);
 
+        /// <summary>Sets the pitch of the sound. A value of 1.0 is the default pitch.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="pitch">The pitch multiplier, where 1.0 is normal pitch.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_set_pitch(ma_sound_ptr pSound, float pitch);
 
+        /// <summary>Retrieves the current pitch of the sound.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <returns>The current pitch multiplier.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_sound_get_pitch(ma_sound_ptr pSound);
 
+        /// <summary>Enables or disables spatialization for the sound. When enabled, the sound will be spatialized based on its position relative to the listener.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="enabled">Whether spatialization is enabled (non-zero) or disabled (0).</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_set_spatialization_enabled(ma_sound_ptr pSound, ma_bool32 enabled);
 
+        /// <summary>Returns whether spatialization is enabled for the sound.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <returns>Non-zero if spatialization is enabled, zero otherwise.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_bool32 ma_sound_is_spatialization_enabled(ma_sound_ptr pSound);
 
+        /// <summary>Pins the sound to a specific listener index, forcing it to always use that listener.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="listenerIndex">The index of the listener to pin the sound to.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_set_pinned_listener_index(ma_sound_ptr pSound, ma_uint32 listenerIndex);
 
+        /// <summary>Returns the pinned listener index for the sound.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <returns>The index of the pinned listener.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_uint32 ma_sound_get_pinned_listener_index(ma_sound_ptr pSound);
 
+        /// <summary>Returns the listener index currently used by the sound for spatialization.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <returns>The index of the currently active listener.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_uint32 ma_sound_get_listener_index(ma_sound_ptr pSound);
 
+        /// <summary>Returns the direction vector from the sound to the active listener.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <returns>A <see cref="ma_vec3f"/> representing the direction to the listener.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_vec3f ma_sound_get_direction_to_listener(ma_sound_ptr pSound);
 
+        /// <summary>Sets the position of the sound in 3D space for spatialization.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="x">The X coordinate of the position.</param>
+        /// <param name="y">The Y coordinate of the position.</param>
+        /// <param name="z">The Z coordinate of the position.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_set_position(ma_sound_ptr pSound, float x, float y, float z);
 
+        /// <summary>Retrieves the current position of the sound in 3D space.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <returns>A <see cref="ma_vec3f"/> containing the sound's position.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_vec3f ma_sound_get_position(ma_sound_ptr pSound);
 
+        /// <summary>Sets the direction the sound is facing in 3D space for directional attenuation.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="x">The X component of the direction vector.</param>
+        /// <param name="y">The Y component of the direction vector.</param>
+        /// <param name="z">The Z component of the direction vector.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_set_direction(ma_sound_ptr pSound, float x, float y, float z);
 
+        /// <summary>Retrieves the current direction the sound is facing.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <returns>A <see cref="ma_vec3f"/> containing the sound's direction vector.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_vec3f ma_sound_get_direction(ma_sound_ptr pSound);
 
+        /// <summary>Sets the velocity of the sound in 3D space for Doppler effect calculation.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="x">The X component of the velocity vector.</param>
+        /// <param name="y">The Y component of the velocity vector.</param>
+        /// <param name="z">The Z component of the velocity vector.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_set_velocity(ma_sound_ptr pSound, float x, float y, float z);
 
+        /// <summary>Retrieves the current velocity of the sound.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <returns>A <see cref="ma_vec3f"/> containing the sound's velocity vector for Doppler effect.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_vec3f ma_sound_get_velocity(ma_sound_ptr pSound);
 
+        /// <summary>Sets the attenuation model for the sound, which controls how volume decreases with distance.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="attenuationModel">The attenuation model to use (e.g. none, inverse, linear, exponential).</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_set_attenuation_model(ma_sound_ptr pSound, ma_attenuation_model attenuationModel);
 
+        /// <summary>Retrieves the current attenuation model of the sound.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <returns>The current attenuation model.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_attenuation_model ma_sound_get_attenuation_model(ma_sound_ptr pSound);
 
+        /// <summary>Sets the positioning mode for the sound (absolute or relative).</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="positioning">The positioning mode.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_set_positioning(ma_sound_ptr pSound, ma_positioning positioning);
 
+        /// <summary>Retrieves the current positioning mode of the sound.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <returns>The current positioning mode.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_positioning ma_sound_get_positioning(ma_sound_ptr pSound);
 
+        /// <summary>Sets the rolloff factor for the sound, controlling the rate of attenuation.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="rolloff">The rolloff factor.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_set_rolloff(ma_sound_ptr pSound, float rolloff);
 
+        /// <summary>Retrieves the current rolloff factor of the sound.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <returns>The current rolloff factor.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_sound_get_rolloff(ma_sound_ptr pSound);
 
+        /// <summary>Sets the minimum gain (volume) of the sound at maximum distance.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="minGain">The minimum gain value, clamped between 0.0 and 1.0.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_set_min_gain(ma_sound_ptr pSound, float minGain);
 
+        /// <summary>Retrieves the current minimum gain of the sound.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <returns>The current minimum gain value.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_sound_get_min_gain(ma_sound_ptr pSound);
 
+        /// <summary>Sets the maximum gain (volume) of the sound at minimum distance.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="maxGain">The maximum gain value, clamped between 0.0 and 1.0.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_set_max_gain(ma_sound_ptr pSound, float maxGain);
 
+        /// <summary>Retrieves the current maximum gain of the sound.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <returns>The current maximum gain value.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_sound_get_max_gain(ma_sound_ptr pSound);
 
+        /// <summary>Sets the minimum distance for the sound's attenuation. At this distance the sound is at max gain.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="minDistance">The minimum distance value.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_set_min_distance(ma_sound_ptr pSound, float minDistance);
 
+        /// <summary>Retrieves the current minimum distance of the sound.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <returns>The current minimum distance value.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_sound_get_min_distance(ma_sound_ptr pSound);
 
+        /// <summary>Sets the maximum distance for the sound's attenuation. At this distance the sound is at min gain.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="maxDistance">The maximum distance value.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_set_max_distance(ma_sound_ptr pSound, float maxDistance);
 
+        /// <summary>Retrieves the current maximum distance of the sound.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <returns>The current maximum distance value.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_sound_get_max_distance(ma_sound_ptr pSound);
 
+        /// <summary>Sets the sound cone parameters for directional attenuation. The cone has an inner angle at full gain and an outer angle at outer gain.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="innerAngleInRadians">The inner cone angle in radians, inside which the sound is at full volume.</param>
+        /// <param name="outerAngleInRadians">The outer cone angle in radians, beyond which the sound is at outer gain.</param>
+        /// <param name="outerGain">The gain applied outside the outer cone angle.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_set_cone(ma_sound_ptr pSound, float innerAngleInRadians, float outerAngleInRadians, float outerGain);
 
+        /// <summary>Retrieves the current cone parameters of the sound.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="pInnerAngleInRadians">Receives the inner cone angle in radians.</param>
+        /// <param name="pOuterAngleInRadians">Receives the outer cone angle in radians.</param>
+        /// <param name="pOuterGain">Receives the outer cone gain.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_get_cone(ma_sound_ptr pSound, out float pInnerAngleInRadians, out float pOuterAngleInRadians, out float pOuterGain);
 
+        /// <summary>Sets the Doppler factor for the sound. Set to 0 to disable the Doppler effect.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="dopplerFactor">The Doppler factor. Set to 0 to disable.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_set_doppler_factor(ma_sound_ptr pSound, float dopplerFactor);
 
+        /// <summary>Retrieves the current Doppler factor of the sound.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <returns>The current Doppler factor.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_sound_get_doppler_factor(ma_sound_ptr pSound);
 
+        /// <summary>Sets the directional attenuation factor for the sound. Set to 0 to disable directional attenuation.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="directionalAttenuationFactor">The directional attenuation factor. Set to 0 to disable.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_set_directional_attenuation_factor(ma_sound_ptr pSound, float directionalAttenuationFactor);
 
+        /// <summary>Retrieves the current directional attenuation factor of the sound.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <returns>The current directional attenuation factor.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_sound_get_directional_attenuation_factor(ma_sound_ptr pSound);
 
+        /// <summary>Schedules a volume fade-in over the specified number of PCM frames, starting immediately.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="volumeBeg">The starting volume of the fade.</param>
+        /// <param name="volumeEnd">The ending volume of the fade.</param>
+        /// <param name="fadeLengthInFrames">The duration of the fade in PCM frames.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_set_fade_in_pcm_frames(ma_sound_ptr pSound, float volumeBeg, float volumeEnd, ma_uint64 fadeLengthInFrames);
 
+        /// <summary>Schedules a volume fade-in over the specified duration in milliseconds, starting immediately.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="volumeBeg">The starting volume of the fade.</param>
+        /// <param name="volumeEnd">The ending volume of the fade.</param>
+        /// <param name="fadeLengthInMilliseconds">The duration of the fade in milliseconds.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_set_fade_in_milliseconds(ma_sound_ptr pSound, float volumeBeg, float volumeEnd, ma_uint64 fadeLengthInMilliseconds);
 
+        /// <summary>Schedules a volume fade starting at a specific global time in PCM frames.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="volumeBeg">The starting volume of the fade.</param>
+        /// <param name="volumeEnd">The ending volume of the fade.</param>
+        /// <param name="fadeLengthInFrames">The duration of the fade in PCM frames.</param>
+        /// <param name="absoluteGlobalTimeInFrames">The absolute global time in PCM frames at which to start the fade.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_set_fade_start_in_pcm_frames(ma_sound_ptr pSound, float volumeBeg, float volumeEnd, ma_uint64 fadeLengthInFrames, ma_uint64 absoluteGlobalTimeInFrames);
 
+        /// <summary>Schedules a volume fade starting at a specific global time in milliseconds.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="volumeBeg">The starting volume of the fade.</param>
+        /// <param name="volumeEnd">The ending volume of the fade.</param>
+        /// <param name="fadeLengthInMilliseconds">The duration of the fade in milliseconds.</param>
+        /// <param name="absoluteGlobalTimeInMilliseconds">The absolute global time in milliseconds at which to start the fade.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_set_fade_start_in_milliseconds(ma_sound_ptr pSound, float volumeBeg, float volumeEnd, ma_uint64 fadeLengthInMilliseconds, ma_uint64 absoluteGlobalTimeInMilliseconds);
 
+        /// <summary>Retrieves the current fade volume of the sound.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <returns>The current fade volume applied to the sound.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_sound_get_current_fade_volume(ma_sound_ptr pSound);
 
+        /// <summary>Schedules the sound to start playing at the specified absolute global time in PCM frames.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="absoluteGlobalTimeInFrames">The absolute global time in PCM frames at which to start the sound.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_set_start_time_in_pcm_frames(ma_sound_ptr pSound, ma_uint64 absoluteGlobalTimeInFrames);
 
+        /// <summary>Schedules the sound to start playing at the specified absolute global time in milliseconds.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="absoluteGlobalTimeInMilliseconds">The absolute global time in milliseconds at which to start the sound.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_set_start_time_in_milliseconds(ma_sound_ptr pSound, ma_uint64 absoluteGlobalTimeInMilliseconds);
 
+        /// <summary>Schedules the sound to stop playing at the specified absolute global time in PCM frames.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="absoluteGlobalTimeInFrames">The absolute global time in PCM frames at which to stop the sound.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_set_stop_time_in_pcm_frames(ma_sound_ptr pSound, ma_uint64 absoluteGlobalTimeInFrames);
 
+        /// <summary>Schedules the sound to stop playing at the specified absolute global time in milliseconds.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="absoluteGlobalTimeInMilliseconds">The absolute global time in milliseconds at which to stop the sound.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_set_stop_time_in_milliseconds(ma_sound_ptr pSound, ma_uint64 absoluteGlobalTimeInMilliseconds);
 
+        /// <summary>Schedules the sound to stop at a specific global time with a fade-out in PCM frames.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="stopAbsoluteGlobalTimeInFrames">The absolute global time in PCM frames at which to stop.</param>
+        /// <param name="fadeLengthInFrames">The fade-out duration in PCM frames.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_set_stop_time_with_fade_in_pcm_frames(ma_sound_ptr pSound, ma_uint64 stopAbsoluteGlobalTimeInFrames, ma_uint64 fadeLengthInFrames);
 
+        /// <summary>Schedules the sound to stop at a specific global time with a fade-out in milliseconds.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="stopAbsoluteGlobalTimeInMilliseconds">The absolute global time in milliseconds at which to stop.</param>
+        /// <param name="fadeLengthInMilliseconds">The fade-out duration in milliseconds.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_set_stop_time_with_fade_in_milliseconds(ma_sound_ptr pSound, ma_uint64 stopAbsoluteGlobalTimeInMilliseconds, ma_uint64 fadeLengthInMilliseconds);
 
+        /// <summary>Returns whether the sound is currently playing.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <returns>Non-zero if the sound is playing, zero otherwise.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_bool32 ma_sound_is_playing(ma_sound_ptr pSound);
 
+        /// <summary>Returns the current playback position of the sound in PCM frames.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <returns>The time in PCM frames since the sound started playing.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_uint64 ma_sound_get_time_in_pcm_frames(ma_sound_ptr pSound);
 
+        /// <summary>Returns the current playback position of the sound in milliseconds.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <returns>The time in milliseconds since the sound started playing.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_uint64 ma_sound_get_time_in_milliseconds(ma_sound_ptr pSound);
 
+        /// <summary>Sets whether the sound should loop when it reaches the end.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="isLooping">Non-zero to enable looping, zero to disable.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_set_looping(ma_sound_ptr pSound, ma_bool32 isLooping);
 
+        /// <summary>Returns whether the sound is set to loop.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <returns>Non-zero if looping is enabled, zero otherwise.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_bool32 ma_sound_is_looping(ma_sound_ptr pSound);
 
+        /// <summary>Returns whether the sound has reached the end of playback.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <returns>Non-zero if the sound has reached the end, zero otherwise.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_bool32 ma_sound_at_end(ma_sound_ptr pSound);
 
+        /// <summary>Seeks to a specific PCM frame in the sound. This is a wrapper around ma_data_source_seek_to_pcm_frame().</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="frameIndex">The PCM frame index to seek to.</param>
+        /// <returns><see cref="ma_result.success"/> on success, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_sound_seek_to_pcm_frame(ma_sound_ptr pSound, ma_uint64 frameIndex); /* Just a wrapper around ma_data_source_seek_to_pcm_frame(). */
 
+        /// <summary>Seeks to a specific time in seconds. Abstraction to ma_sound_seek_to_pcm_frame().</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="seekPointInSeconds">The time in seconds to seek to.</param>
+        /// <returns><see cref="ma_result.success"/> on success, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_sound_seek_to_second(ma_sound_ptr pSound, float seekPointInSeconds); /* Abstraction to ma_sound_seek_to_pcm_frame() */
 
+        /// <summary>Retrieves the data format (sample format, channels, sample rate) of the sound.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="pFormat">Receives the sample format (e.g. f32, s16).</param>
+        /// <param name="pChannels">Receives the number of channels.</param>
+        /// <param name="pSampleRate">Receives the sample rate in Hz.</param>
+        /// <param name="pChannelMap">Receives the channel map. Can be 0 if not needed.</param>
+        /// <param name="channelMapCap">The capacity of the channel map buffer.</param>
+        /// <returns><see cref="ma_result.success"/> on success, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_sound_get_data_format(ma_sound_ptr pSound, out ma_format pFormat, out ma_uint32 pChannels, out ma_uint32 pSampleRate, Byte pChannelMap, size_t channelMapCap);
 
+        /// <summary>Retrieves the current playback cursor position in PCM frames.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="pCursor">Receives the current cursor position in PCM frames.</param>
+        /// <returns><see cref="ma_result.success"/> on success, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_sound_get_cursor_in_pcm_frames(ma_sound_ptr pSound, out ma_uint64 pCursor);
 
+        /// <summary>Retrieves the total length of the sound in PCM frames.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="pLength">Receives the total length in PCM frames.</param>
+        /// <returns><see cref="ma_result.success"/> on success, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_sound_get_length_in_pcm_frames(ma_sound_ptr pSound, out ma_uint64 pLength);
 
+        /// <summary>Retrieves the current playback cursor position in seconds.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="pCursor">Receives the current cursor position in seconds.</param>
+        /// <returns><see cref="ma_result.success"/> on success, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_sound_get_cursor_in_seconds(ma_sound_ptr pSound, out float pCursor);
 
+        /// <summary>Retrieves the total length of the sound in seconds.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="pLength">Receives the total length in seconds.</param>
+        /// <returns><see cref="ma_result.success"/> on success, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_sound_get_length_in_seconds(ma_sound_ptr pSound, out float pLength);
 
+        /// <summary>Sets the callback that is called when the sound reaches the end of playback. Extern version using raw function pointer.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="callback">Raw function pointer to the callback.</param>
+        /// <param name="pUserData">User data pointer passed to the callback.</param>
+        /// <returns><see cref="ma_result.success"/> on success, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_sound_set_end_callback(ma_sound_ptr pSound, IntPtr callback, IntPtr pUserData);
 
+        /// <summary>Sets the callback that is called when the sound reaches the end of playback. Managed version using a delegate.</summary>
+        /// <param name="pSound">Pointer to the sound.</param>
+        /// <param name="callback">The delegate to invoke at end of playback.</param>
+        /// <param name="pUserData">User data pointer passed to the callback.</param>
+        /// <returns><see cref="ma_result.success"/> on success, otherwise an error code.</returns>
         public static ma_result ma_sound_set_end_callback(ma_sound_ptr pSound, ma_sound_end_proc callback, IntPtr pUserData)
         {
             return ma_sound_set_end_callback(pSound, MarshalHelper.GetFunctionPointerForDelegate(callback), pUserData);
         }
 
         // ma_sound_group
+        /// <summary>Initializes a sound group. Sounds can be attached to a group to control their properties collectively.</summary>
+        /// <param name="pEngine">The engine to use.</param>
+        /// <param name="flags">Flags controlling playback behavior.</param>
+        /// <param name="pParentGroup">Optional parent sound group. Pass IntPtr.Zero for no parent.</param>
+        /// <param name="pGroup">Pointer to the sound group to initialize.</param>
+        /// <returns><see cref="ma_result.success"/> on success, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_sound_group_init(ma_engine_ptr pEngine, ma_sound_flags flags, ma_sound_group_ptr pParentGroup, ma_sound_group_ptr pGroup);
 
+        /// <summary>Initializes a sound group with full configuration for maximum flexibility.</summary>
+        /// <param name="pEngine">The engine to use.</param>
+        /// <param name="pConfig">The full sound group configuration.</param>
+        /// <param name="pGroup">Pointer to the sound group to initialize.</param>
+        /// <returns><see cref="ma_result.success"/> on success, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_sound_group_init_ex(ma_engine_ptr pEngine, ref ma_sound_group_config pConfig, ma_sound_group_ptr pGroup);
 
+        /// <summary>Uninitializes and frees resources associated with a sound group.</summary>
+        /// <param name="pGroup">Pointer to the sound group to uninitialize.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_group_uninit(ma_sound_group_ptr pGroup);
 
+        /// <summary>Retrieves the engine that owns this sound group.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <returns>Pointer to the engine that owns the sound group.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_engine_ptr ma_sound_group_get_engine(ma_sound_group_ptr pGroup);
 
+        /// <summary>Starts playback of all sounds in the group.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <returns><see cref="ma_result.success"/> on success, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_sound_group_start(ma_sound_group_ptr pGroup);
 
+        /// <summary>Stops playback of all sounds in the group.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <returns><see cref="ma_result.success"/> on success, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_sound_group_stop(ma_sound_group_ptr pGroup);
 
+        /// <summary>Sets the volume for all sounds in the group. A value of 1.0 is the default volume.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <param name="volume">The volume level, where 0.0 is silence and 1.0 is default.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_group_set_volume(ma_sound_group_ptr pGroup, float volume);
 
+        /// <summary>Retrieves the current volume of the sound group.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <returns>The current volume level.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_sound_group_get_volume(ma_sound_group_ptr pGroup);
 
+        /// <summary>Sets the pan for all sounds in the group. -1.0 is left, 0.0 is center, 1.0 is right.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <param name="pan">The pan value, typically between -1.0 (left) and 1.0 (right).</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_group_set_pan(ma_sound_group_ptr pGroup, float pan);
 
+        /// <summary>Retrieves the current pan of the sound group.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <returns>The current pan value.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_sound_group_get_pan(ma_sound_group_ptr pGroup);
 
+        /// <summary>Sets the pan mode for all sounds in the group.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <param name="panMode">The panning mode (e.g. balance or pan).</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_group_set_pan_mode(ma_sound_group_ptr pGroup, ma_pan_mode panMode);
 
+        /// <summary>Retrieves the current pan mode of the sound group.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <returns>The current pan mode.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_pan_mode ma_sound_group_get_pan_mode(ma_sound_group_ptr pGroup);
 
+        /// <summary>Sets the pitch for all sounds in the group. A value of 1.0 is the default pitch.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <param name="pitch">The pitch multiplier, where 1.0 is normal pitch.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_group_set_pitch(ma_sound_group_ptr pGroup, float pitch);
 
+        /// <summary>Retrieves the current pitch of the sound group.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <returns>The current pitch multiplier.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_sound_group_get_pitch(ma_sound_group_ptr pGroup);
 
+        /// <summary>Enables or disables spatialization for all sounds in the group.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <param name="enabled">Whether spatialization is enabled (non-zero) or disabled (0).</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_group_set_spatialization_enabled(ma_sound_group_ptr pGroup, ma_bool32 enabled);
 
+        /// <summary>Returns whether spatialization is enabled for the sound group.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <returns>Non-zero if spatialization is enabled, zero otherwise.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_bool32 ma_sound_group_is_spatialization_enabled(ma_sound_group_ptr pGroup);
 
+        /// <summary>Pins all sounds in the group to a specific listener index.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <param name="listenerIndex">The index of the listener to pin to.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_group_set_pinned_listener_index(ma_sound_group_ptr pGroup, ma_uint32 listenerIndex);
 
+        /// <summary>Returns the pinned listener index for the sound group.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <returns>The index of the pinned listener.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_uint32 ma_sound_group_get_pinned_listener_index(ma_sound_group_ptr pGroup);
 
+        /// <summary>Returns the listener index currently used by the sound group for spatialization.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <returns>The index of the currently active listener.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_uint32 ma_sound_group_get_listener_index(ma_sound_group_ptr pGroup);
 
+        /// <summary>Returns the direction vector from the sound group to the active listener.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <returns>A <see cref="ma_vec3f"/> representing the direction to the listener.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_vec3f ma_sound_group_get_direction_to_listener(ma_sound_group_ptr pGroup);
 
+        /// <summary>Sets the position of the sound group in 3D space for spatialization.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <param name="x">The X coordinate of the position.</param>
+        /// <param name="y">The Y coordinate of the position.</param>
+        /// <param name="z">The Z coordinate of the position.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_group_set_position(ma_sound_group_ptr pGroup, float x, float y, float z);
 
+        /// <summary>Retrieves the current position of the sound group in 3D space.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <returns>A <see cref="ma_vec3f"/> containing the sound group's position.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_vec3f ma_sound_group_get_position(ma_sound_group_ptr pGroup);
 
+        /// <summary>Sets the direction the sound group is facing in 3D space for directional attenuation.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <param name="x">The X component of the direction vector.</param>
+        /// <param name="y">The Y component of the direction vector.</param>
+        /// <param name="z">The Z component of the direction vector.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_group_set_direction(ma_sound_group_ptr pGroup, float x, float y, float z);
 
+        /// <summary>Retrieves the current direction the sound group is facing.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <returns>A <see cref="ma_vec3f"/> containing the sound group's direction vector.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_vec3f ma_sound_group_get_direction(ma_sound_group_ptr pGroup);
 
+        /// <summary>Sets the velocity of the sound group in 3D space for Doppler effect calculation.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <param name="x">The X component of the velocity vector.</param>
+        /// <param name="y">The Y component of the velocity vector.</param>
+        /// <param name="z">The Z component of the velocity vector.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_group_set_velocity(ma_sound_group_ptr pGroup, float x, float y, float z);
 
+        /// <summary>Retrieves the current velocity of the sound group.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <returns>A <see cref="ma_vec3f"/> containing the sound group's velocity vector.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_vec3f ma_sound_group_get_velocity(ma_sound_group_ptr pGroup);
 
+        /// <summary>Sets the attenuation model for the sound group, which controls how volume decreases with distance.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <param name="attenuationModel">The attenuation model to use (e.g. none, inverse, linear, exponential).</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_group_set_attenuation_model(ma_sound_group_ptr pGroup, ma_attenuation_model attenuationModel);
 
+        /// <summary>Retrieves the current attenuation model of the sound group.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <returns>The current attenuation model.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_attenuation_model ma_sound_group_get_attenuation_model(ma_sound_group_ptr pGroup);
 
+        /// <summary>Sets the positioning mode for the sound group (absolute or relative).</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <param name="positioning">The positioning mode.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_group_set_positioning(ma_sound_group_ptr pGroup, ma_positioning positioning);
 
+        /// <summary>Retrieves the current positioning mode of the sound group.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <returns>The current positioning mode.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_positioning ma_sound_group_get_positioning(ma_sound_group_ptr pGroup);
 
+        /// <summary>Sets the rolloff factor for the sound group, controlling the rate of attenuation.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <param name="rolloff">The rolloff factor.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_group_set_rolloff(ma_sound_group_ptr pGroup, float rolloff);
 
+        /// <summary>Retrieves the current rolloff factor of the sound group.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <returns>The current rolloff factor.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_sound_group_get_rolloff(ma_sound_group_ptr pGroup);
 
+        /// <summary>Sets the minimum gain (volume) of the sound group at maximum distance.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <param name="minGain">The minimum gain value.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_group_set_min_gain(ma_sound_group_ptr pGroup, float minGain);
 
+        /// <summary>Retrieves the current minimum gain of the sound group.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <returns>The current minimum gain value.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_sound_group_get_min_gain(ma_sound_group_ptr pGroup);
 
+        /// <summary>Sets the maximum gain (volume) of the sound group at minimum distance.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <param name="maxGain">The maximum gain value.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_group_set_max_gain(ma_sound_group_ptr pGroup, float maxGain);
 
+        /// <summary>Retrieves the current maximum gain of the sound group.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <returns>The current maximum gain value.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_sound_group_get_max_gain(ma_sound_group_ptr pGroup);
 
+        /// <summary>Sets the minimum distance for the sound group's attenuation. At this distance sounds are at max gain.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <param name="minDistance">The minimum distance value.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_group_set_min_distance(ma_sound_group_ptr pGroup, float minDistance);
 
+        /// <summary>Retrieves the current minimum distance of the sound group.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <returns>The current minimum distance value.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_sound_group_get_min_distance(ma_sound_group_ptr pGroup);
 
+        /// <summary>Sets the maximum distance for the sound group's attenuation. At this distance sounds are at min gain.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <param name="maxDistance">The maximum distance value.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_group_set_max_distance(ma_sound_group_ptr pGroup, float maxDistance);
 
+        /// <summary>Retrieves the current maximum distance of the sound group.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <returns>The current maximum distance value.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_sound_group_get_max_distance(ma_sound_group_ptr pGroup);
 
+        /// <summary>Sets the cone parameters for the sound group. The cone has an inner angle at full gain and an outer angle at outer gain.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <param name="innerAngleInRadians">The inner cone angle in radians, inside which sounds are at full volume.</param>
+        /// <param name="outerAngleInRadians">The outer cone angle in radians, beyond which sounds are at outer gain.</param>
+        /// <param name="outerGain">The gain applied outside the outer cone angle.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_group_set_cone(ma_sound_group_ptr pGroup, float innerAngleInRadians, float outerAngleInRadians, float outerGain);
 
+        /// <summary>Retrieves the current cone parameters of the sound group.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <param name="pInnerAngleInRadians">Receives the inner cone angle in radians.</param>
+        /// <param name="pOuterAngleInRadians">Receives the outer cone angle in radians.</param>
+        /// <param name="pOuterGain">Receives the outer cone gain.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_group_get_cone(ma_sound_group_ptr pGroup, out float pInnerAngleInRadians, out float pOuterAngleInRadians, out float pOuterGain);
 
+        /// <summary>Sets the Doppler factor for the sound group. Set to 0 to disable the Doppler effect.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <param name="dopplerFactor">The Doppler factor. Set to 0 to disable.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_group_set_doppler_factor(ma_sound_group_ptr pGroup, float dopplerFactor);
 
+        /// <summary>Retrieves the current Doppler factor of the sound group.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <returns>The current Doppler factor.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_sound_group_get_doppler_factor(ma_sound_group_ptr pGroup);
 
+        /// <summary>Sets the directional attenuation factor for the sound group. Set to 0 to disable directional attenuation.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <param name="directionalAttenuationFactor">The directional attenuation factor. Set to 0 to disable.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_group_set_directional_attenuation_factor(ma_sound_group_ptr pGroup, float directionalAttenuationFactor);
 
+        /// <summary>Retrieves the current directional attenuation factor of the sound group.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <returns>The current directional attenuation factor.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_sound_group_get_directional_attenuation_factor(ma_sound_group_ptr pGroup);
 
+        /// <summary>Schedules a volume fade-in for the sound group over the specified number of PCM frames, starting immediately.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <param name="volumeBeg">The starting volume of the fade.</param>
+        /// <param name="volumeEnd">The ending volume of the fade.</param>
+        /// <param name="fadeLengthInFrames">The duration of the fade in PCM frames.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_group_set_fade_in_pcm_frames(ma_sound_group_ptr pGroup, float volumeBeg, float volumeEnd, ma_uint64 fadeLengthInFrames);
 
+        /// <summary>Schedules a volume fade-in for the sound group over the specified duration in milliseconds, starting immediately.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <param name="volumeBeg">The starting volume of the fade.</param>
+        /// <param name="volumeEnd">The ending volume of the fade.</param>
+        /// <param name="fadeLengthInMilliseconds">The duration of the fade in milliseconds.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_group_set_fade_in_milliseconds(ma_sound_group_ptr pGroup, float volumeBeg, float volumeEnd, ma_uint64 fadeLengthInMilliseconds);
 
+        /// <summary>Retrieves the current fade volume of the sound group.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <returns>The current fade volume applied to the sound group.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_sound_group_get_current_fade_volume(ma_sound_group_ptr pGroup);
 
+        /// <summary>Schedules the sound group to start playing at the specified absolute global time in PCM frames.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <param name="absoluteGlobalTimeInFrames">The absolute global time in PCM frames at which to start.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_group_set_start_time_in_pcm_frames(ma_sound_group_ptr pGroup, ma_uint64 absoluteGlobalTimeInFrames);
 
+        /// <summary>Schedules the sound group to start playing at the specified absolute global time in milliseconds.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <param name="absoluteGlobalTimeInMilliseconds">The absolute global time in milliseconds at which to start.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_group_set_start_time_in_milliseconds(ma_sound_group_ptr pGroup, ma_uint64 absoluteGlobalTimeInMilliseconds);
 
+        /// <summary>Schedules the sound group to stop playing at the specified absolute global time in PCM frames.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <param name="absoluteGlobalTimeInFrames">The absolute global time in PCM frames at which to stop.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_group_set_stop_time_in_pcm_frames(ma_sound_group_ptr pGroup, ma_uint64 absoluteGlobalTimeInFrames);
 
+        /// <summary>Schedules the sound group to stop playing at the specified absolute global time in milliseconds.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <param name="absoluteGlobalTimeInMilliseconds">The absolute global time in milliseconds at which to stop.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_sound_group_set_stop_time_in_milliseconds(ma_sound_group_ptr pGroup, ma_uint64 absoluteGlobalTimeInMilliseconds);
 
+        /// <summary>Returns whether the sound group is currently playing.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <returns>Non-zero if playing, zero otherwise.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_bool32 ma_sound_group_is_playing(ma_sound_group_ptr pGroup);
 
+        /// <summary>Returns the current playback position of the sound group in PCM frames.</summary>
+        /// <param name="pGroup">Pointer to the sound group.</param>
+        /// <returns>The time in PCM frames since the sound group started playing.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_uint64 ma_sound_group_get_time_in_pcm_frames(ma_sound_group_ptr pGroup);
 
@@ -796,238 +1727,499 @@ namespace MiniAudioEx.Native
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern ma_procedural_data_source_config ma_procedural_data_source_config_init(ma_format format, ma_uint32 channels, ma_uint32 sampleRate, IntPtr pProceduralSoundProc, IntPtr pUserData);
 
+        /// <summary>Initializes a procedural data source configuration for generating audio programmatically.</summary>
+        /// <param name="format">The sample format (e.g. f32, s16).</param>
+        /// <param name="channels">The number of audio channels.</param>
+        /// <param name="sampleRate">The sample rate in Hz.</param>
+        /// <param name="pProceduralSoundProc">The delegate to call for generating audio data.</param>
+        /// <param name="pUserData">User data pointer passed to the callback.</param>
+        /// <returns>A configured <see cref="ma_procedural_data_source_config"/>.</returns>
         public static ma_procedural_data_source_config ma_procedural_data_source_config_init(ma_format format, ma_uint32 channels, ma_uint32 sampleRate, ma_procedural_data_source_proc pProceduralSoundProc, IntPtr pUserData)
         {
             return ma_procedural_data_source_config_init(format, channels, sampleRate, MarshalHelper.GetFunctionPointerForDelegate(pProceduralSoundProc), pUserData);
         }
         
+        /// <summary>Initializes a procedural data source for programmatic audio generation.</summary>
+        /// <param name="pConfig">The configuration specifying format, channels, sample rate and callback.</param>
+        /// <param name="pProceduralSound">Pointer to the procedural data source to initialize.</param>
+        /// <returns><see cref="ma_result.success"/> on success, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_procedural_data_source_init(ref ma_procedural_data_source_config pConfig, ma_procedural_data_source_ptr pProceduralSound);
 
+        /// <summary>Uninitializes and frees resources associated with a procedural data source.</summary>
+        /// <param name="pProceduralSound">Pointer to the procedural data source to uninitialize.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_procedural_data_source_uninit(ma_procedural_data_source_ptr pProceduralSound);
 
         // ma_spatializer_listener
+        /// <summary>Initializes a spatializer listener configuration with a given number of output channels.</summary>
+        /// <param name="channelsOut">The number of output channels for the listener.</param>
+        /// <returns>A configured <see cref="ma_spatializer_listener_config"/>.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_spatializer_listener_config ma_spatializer_listener_config_init(ma_uint32 channelsOut);
 
+        /// <summary>Calculates the heap size required for a spatializer listener.</summary>
+        /// <param name="pConfig">The listener configuration.</param>
+        /// <param name="pHeapSizeInBytes">Receives the required heap size in bytes.</param>
+        /// <returns><see cref="ma_result.success"/> on success, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_spatializer_listener_get_heap_size(ref ma_spatializer_listener_config pConfig, out size_t pHeapSizeInBytes);
 
+        /// <summary>Initializes a spatializer listener using a pre-allocated heap buffer.</summary>
+        /// <param name="pConfig">The listener configuration.</param>
+        /// <param name="pHeap">Pointer to the pre-allocated heap buffer.</param>
+        /// <param name="pListener">Pointer to the listener to initialize.</param>
+        /// <returns><see cref="ma_result.success"/> on success, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_spatializer_listener_init_preallocated(ref ma_spatializer_listener_config pConfig, IntPtr pHeap, ma_spatializer_listener_ptr pListener);
 
+        /// <summary>Initializes a spatializer listener with custom allocation callbacks.</summary>
+        /// <param name="pConfig">The listener configuration.</param>
+        /// <param name="pAllocationCallbacks">Optional allocation callbacks. Pass IntPtr.Zero for defaults.</param>
+        /// <param name="pListener">Pointer to the listener to initialize.</param>
+        /// <returns><see cref="ma_result.success"/> on success, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_spatializer_listener_init(ref ma_spatializer_listener_config pConfig, IntPtr pAllocationCallbacks, ma_spatializer_listener_ptr pListener);
 
+        /// <summary>Uninitializes and frees resources associated with a spatializer listener.</summary>
+        /// <param name="pListener">Pointer to the listener to uninitialize.</param>
+        /// <param name="pAllocationCallbacks">Optional allocation callbacks. Pass IntPtr.Zero for defaults.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_spatializer_listener_uninit(ma_spatializer_listener_ptr pListener, IntPtr pAllocationCallbacks);
 
+        /// <summary>Retrieves the channel map of the spatializer listener.</summary>
+        /// <param name="pListener">Pointer to the listener.</param>
+        /// <returns>Pointer to the channel map.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_channel_ptr ma_spatializer_listener_get_channel_map(ma_spatializer_listener_ptr pListener);
 
+        /// <summary>Sets the cone parameters for the spatializer listener.</summary>
+        /// <param name="pListener">Pointer to the listener.</param>
+        /// <param name="innerAngleInRadians">The inner cone angle in radians, inside which the listener hears at full volume.</param>
+        /// <param name="outerAngleInRadians">The outer cone angle in radians, beyond which the listener hears at outer gain.</param>
+        /// <param name="outerGain">The gain applied outside the outer cone angle.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_spatializer_listener_set_cone(ma_spatializer_listener_ptr pListener, float innerAngleInRadians, float outerAngleInRadians, float outerGain);
 
+        /// <summary>Retrieves the current cone parameters of the spatializer listener.</summary>
+        /// <param name="pListener">Pointer to the listener.</param>
+        /// <param name="pInnerAngleInRadians">Receives the inner cone angle in radians.</param>
+        /// <param name="pOuterAngleInRadians">Receives the outer cone angle in radians.</param>
+        /// <param name="pOuterGain">Receives the outer cone gain.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_spatializer_listener_get_cone(ma_spatializer_listener_ptr pListener, out float pInnerAngleInRadians, out float pOuterAngleInRadians, out float pOuterGain);
 
+        /// <summary>Sets the position of the spatializer listener in 3D space.</summary>
+        /// <param name="pListener">Pointer to the listener.</param>
+        /// <param name="x">The X coordinate of the position.</param>
+        /// <param name="y">The Y coordinate of the position.</param>
+        /// <param name="z">The Z coordinate of the position.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_spatializer_listener_set_position(ma_spatializer_listener_ptr pListener, float x, float y, float z);
 
+        /// <summary>Retrieves the current position of the spatializer listener.</summary>
+        /// <param name="pListener">Pointer to the listener.</param>
+        /// <returns>A <see cref="ma_vec3f"/> containing the listener's position.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_vec3f ma_spatializer_listener_get_position(ma_spatializer_listener_ptr pListener);
 
+        /// <summary>Sets the direction the spatializer listener is facing in 3D space.</summary>
+        /// <param name="pListener">Pointer to the listener.</param>
+        /// <param name="x">The X component of the direction vector.</param>
+        /// <param name="y">The Y component of the direction vector.</param>
+        /// <param name="z">The Z component of the direction vector.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_spatializer_listener_set_direction(ma_spatializer_listener_ptr pListener, float x, float y, float z);
 
+        /// <summary>Retrieves the current direction the spatializer listener is facing.</summary>
+        /// <param name="pListener">Pointer to the listener.</param>
+        /// <returns>A <see cref="ma_vec3f"/> containing the listener's direction vector.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_vec3f ma_spatializer_listener_get_direction(ma_spatializer_listener_ptr pListener);
 
+        /// <summary>Sets the velocity of the spatializer listener for Doppler effect calculation.</summary>
+        /// <param name="pListener">Pointer to the listener.</param>
+        /// <param name="x">The X component of the velocity vector.</param>
+        /// <param name="y">The Y component of the velocity vector.</param>
+        /// <param name="z">The Z component of the velocity vector.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_spatializer_listener_set_velocity(ma_spatializer_listener_ptr pListener, float x, float y, float z);
 
+        /// <summary>Retrieves the current velocity of the spatializer listener.</summary>
+        /// <param name="pListener">Pointer to the listener.</param>
+        /// <returns>A <see cref="ma_vec3f"/> containing the listener's velocity vector.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_vec3f ma_spatializer_listener_get_velocity(ma_spatializer_listener_ptr pListener);
 
+        /// <summary>Sets the speed of sound for the spatializer listener, used in Doppler effect calculation.</summary>
+        /// <param name="pListener">Pointer to the listener.</param>
+        /// <param name="speedOfSound">The speed of sound value.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_spatializer_listener_set_speed_of_sound(ma_spatializer_listener_ptr pListener, float speedOfSound);
 
+        /// <summary>Retrieves the current speed of sound of the spatializer listener.</summary>
+        /// <param name="pListener">Pointer to the listener.</param>
+        /// <returns>The current speed of sound value.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_spatializer_listener_get_speed_of_sound(ma_spatializer_listener_ptr pListener);
 
+        /// <summary>Sets the world up vector for the spatializer listener.</summary>
+        /// <param name="pListener">Pointer to the listener.</param>
+        /// <param name="x">The X component of the world up vector.</param>
+        /// <param name="y">The Y component of the world up vector.</param>
+        /// <param name="z">The Z component of the world up vector.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_spatializer_listener_set_world_up(ma_spatializer_listener_ptr pListener, float x, float y, float z);
 
+        /// <summary>Retrieves the current world up vector of the spatializer listener.</summary>
+        /// <param name="pListener">Pointer to the listener.</param>
+        /// <returns>A <see cref="ma_vec3f"/> containing the world up vector.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_vec3f ma_spatializer_listener_get_world_up(ma_spatializer_listener_ptr pListener);
 
+        /// <summary>Enables or disables the spatializer listener.</summary>
+        /// <param name="pListener">Pointer to the listener.</param>
+        /// <param name="isEnabled">Non-zero to enable, zero to disable.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_spatializer_listener_set_enabled(ma_spatializer_listener_ptr pListener, ma_bool32 isEnabled);
 
+        /// <summary>Returns whether the spatializer listener is enabled.</summary>
+        /// <param name="pListener">Pointer to the listener.</param>
+        /// <returns>Non-zero if enabled, zero otherwise.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_bool32 ma_spatializer_listener_is_enabled(ma_spatializer_listener_ptr pListener);
 
         // ma_spatializer
+        /// <summary>Initializes a spatializer configuration with the given input and output channel counts.</summary>
+        /// <param name="channelsIn">The number of input channels.</param>
+        /// <param name="channelsOut">The number of output channels.</param>
+        /// <returns>A configured <see cref="ma_spatializer_config"/>.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_spatializer_config ma_spatializer_config_init(ma_uint32 channelsIn, ma_uint32 channelsOut);
 
+        /// <summary>Calculates the heap size required for a spatializer.</summary>
+        /// <param name="pConfig">The spatializer configuration.</param>
+        /// <param name="pHeapSizeInBytes">Receives the required heap size in bytes.</param>
+        /// <returns><see cref="ma_result.success"/> on success, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_spatializer_get_heap_size(ref ma_spatializer_config pConfig, out size_t pHeapSizeInBytes);
 
+        /// <summary>Initializes a spatializer using a pre-allocated heap buffer.</summary>
+        /// <param name="pConfig">The spatializer configuration.</param>
+        /// <param name="pHeap">Pointer to the pre-allocated heap buffer.</param>
+        /// <param name="pSpatializer">Pointer to the spatializer to initialize.</param>
+        /// <returns><see cref="ma_result.success"/> on success, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_spatializer_init_preallocated(ref ma_spatializer_config pConfig, IntPtr pHeap, ma_spatializer_ptr pSpatializer);
 
+        /// <summary>Initializes a spatializer with custom allocation callbacks.</summary>
+        /// <param name="pConfig">The spatializer configuration.</param>
+        /// <param name="pAllocationCallbacks">Optional allocation callbacks. Pass IntPtr.Zero for defaults.</param>
+        /// <param name="pSpatializer">Pointer to the spatializer to initialize.</param>
+        /// <returns><see cref="ma_result.success"/> on success, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_spatializer_init(ref ma_spatializer_config pConfig, IntPtr pAllocationCallbacks, ma_spatializer_ptr pSpatializer);
 
+        /// <summary>Uninitializes and frees resources associated with a spatializer.</summary>
+        /// <param name="pSpatializer">Pointer to the spatializer to uninitialize.</param>
+        /// <param name="pAllocationCallbacks">Optional allocation callbacks. Pass IntPtr.Zero for defaults.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_spatializer_uninit(ma_spatializer_ptr pSpatializer, IntPtr pAllocationCallbacks);
 
+        /// <summary>Processes PCM frames through the spatializer, applying 3D spatial effects based on the listener position.</summary>
+        /// <param name="pSpatializer">Pointer to the spatializer.</param>
+        /// <param name="pListener">Pointer to the spatializer listener providing position/direction context.</param>
+        /// <param name="pFramesOut">Pointer to the output buffer for processed frames.</param>
+        /// <param name="pFramesIn">Pointer to the input buffer of source frames.</param>
+        /// <param name="frameCount">The number of PCM frames to process.</param>
+        /// <returns><see cref="ma_result.success"/> on success, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_spatializer_process_pcm_frames(ma_spatializer_ptr pSpatializer, ma_spatializer_listener_ptr pListener, IntPtr pFramesOut, IntPtr pFramesIn, ma_uint64 frameCount);
 
+        /// <summary>Sets the master volume of the spatializer.</summary>
+        /// <param name="pSpatializer">Pointer to the spatializer.</param>
+        /// <param name="volume">The volume level.</param>
+        /// <returns><see cref="ma_result.success"/> on success, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_spatializer_set_master_volume(ma_spatializer_ptr pSpatializer, float volume);
 
+        /// <summary>Retrieves the master volume of the spatializer.</summary>
+        /// <param name="pSpatializer">Pointer to the spatializer.</param>
+        /// <param name="pVolume">Receives the current master volume.</param>
+        /// <returns><see cref="ma_result.success"/> on success, otherwise an error code.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_spatializer_get_master_volume(ma_spatializer_ptr pSpatializer, out float pVolume);
 
+        /// <summary>Retrieves the number of input channels of the spatializer.</summary>
+        /// <param name="pSpatializer">Pointer to the spatializer.</param>
+        /// <returns>The number of input channels.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_uint32 ma_spatializer_get_input_channels(ma_spatializer_ptr pSpatializer);
 
+        /// <summary>Retrieves the number of output channels of the spatializer.</summary>
+        /// <param name="pSpatializer">Pointer to the spatializer.</param>
+        /// <returns>The number of output channels.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_uint32 ma_spatializer_get_output_channels(ma_spatializer_ptr pSpatializer);
 
+        /// <summary>Sets the attenuation model for the spatializer.</summary>
+        /// <param name="pSpatializer">Pointer to the spatializer.</param>
+        /// <param name="attenuationModel">The attenuation model to use.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_spatializer_set_attenuation_model(ma_spatializer_ptr pSpatializer, ma_attenuation_model attenuationModel);
 
+        /// <summary>Retrieves the current attenuation model of the spatializer.</summary>
+        /// <param name="pSpatializer">Pointer to the spatializer.</param>
+        /// <returns>The current attenuation model.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_attenuation_model ma_spatializer_get_attenuation_model(ma_spatializer_ptr pSpatializer);
 
+        /// <summary>Sets the positioning mode for the spatializer.</summary>
+        /// <param name="pSpatializer">Pointer to the spatializer.</param>
+        /// <param name="positioning">The positioning mode.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_spatializer_set_positioning(ma_spatializer_ptr pSpatializer, ma_positioning positioning);
 
+        /// <summary>Retrieves the current positioning mode of the spatializer.</summary>
+        /// <param name="pSpatializer">Pointer to the spatializer.</param>
+        /// <returns>The current positioning mode.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_positioning ma_spatializer_get_positioning(ma_spatializer_ptr pSpatializer);
 
+        /// <summary>Sets the rolloff factor for the spatializer.</summary>
+        /// <param name="pSpatializer">Pointer to the spatializer.</param>
+        /// <param name="rolloff">The rolloff factor.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_spatializer_set_rolloff(ma_spatializer_ptr pSpatializer, float rolloff);
 
+        /// <summary>Retrieves the current rolloff factor of the spatializer.</summary>
+        /// <param name="pSpatializer">Pointer to the spatializer.</param>
+        /// <returns>The current rolloff factor.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_spatializer_get_rolloff(ma_spatializer_ptr pSpatializer);
 
+        /// <summary>Sets the minimum gain of the spatializer.</summary>
+        /// <param name="pSpatializer">Pointer to the spatializer.</param>
+        /// <param name="minGain">The minimum gain value.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_spatializer_set_min_gain(ma_spatializer_ptr pSpatializer, float minGain);
 
+        /// <summary>Retrieves the current minimum gain of the spatializer.</summary>
+        /// <param name="pSpatializer">Pointer to the spatializer.</param>
+        /// <returns>The current minimum gain value.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_spatializer_get_min_gain(ma_spatializer_ptr pSpatializer);
 
+        /// <summary>Sets the maximum gain of the spatializer.</summary>
+        /// <param name="pSpatializer">Pointer to the spatializer.</param>
+        /// <param name="maxGain">The maximum gain value.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_spatializer_set_max_gain(ma_spatializer_ptr pSpatializer, float maxGain);
 
+        /// <summary>Retrieves the current maximum gain of the spatializer.</summary>
+        /// <param name="pSpatializer">Pointer to the spatializer.</param>
+        /// <returns>The current maximum gain value.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_spatializer_get_max_gain(ma_spatializer_ptr pSpatializer);
 
+        /// <summary>Sets the minimum distance of the spatializer.</summary>
+        /// <param name="pSpatializer">Pointer to the spatializer.</param>
+        /// <param name="minDistance">The minimum distance value.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_spatializer_set_min_distance(ma_spatializer_ptr pSpatializer, float minDistance);
 
+        /// <summary>Retrieves the current minimum distance of the spatializer.</summary>
+        /// <param name="pSpatializer">Pointer to the spatializer.</param>
+        /// <returns>The current minimum distance value.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_spatializer_get_min_distance(ma_spatializer_ptr pSpatializer);
 
+        /// <summary>Sets the maximum distance of the spatializer.</summary>
+        /// <param name="pSpatializer">Pointer to the spatializer.</param>
+        /// <param name="maxDistance">The maximum distance value.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_spatializer_set_max_distance(ma_spatializer_ptr pSpatializer, float maxDistance);
 
+        /// <summary>Retrieves the current maximum distance of the spatializer.</summary>
+        /// <param name="pSpatializer">Pointer to the spatializer.</param>
+        /// <returns>The current maximum distance value.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_spatializer_get_max_distance(ma_spatializer_ptr pSpatializer);
 
+        /// <summary>Sets the cone parameters for the spatializer.</summary>
+        /// <param name="pSpatializer">Pointer to the spatializer.</param>
+        /// <param name="innerAngleInRadians">The inner cone angle in radians.</param>
+        /// <param name="outerAngleInRadians">The outer cone angle in radians.</param>
+        /// <param name="outerGain">The gain applied outside the outer cone angle.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_spatializer_set_cone(ma_spatializer_ptr pSpatializer, float innerAngleInRadians, float outerAngleInRadians, float outerGain);
 
+        /// <summary>Retrieves the current cone parameters of the spatializer.</summary>
+        /// <param name="pSpatializer">Pointer to the spatializer.</param>
+        /// <param name="pInnerAngleInRadians">Receives the inner cone angle in radians.</param>
+        /// <param name="pOuterAngleInRadians">Receives the outer cone angle in radians.</param>
+        /// <param name="pOuterGain">Receives the outer cone gain.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_spatializer_get_cone(ma_spatializer_ptr pSpatializer, out float pInnerAngleInRadians, out float pOuterAngleInRadians, out float pOuterGain);
 
+        /// <summary>Sets the Doppler factor for the spatializer. Set to 0 to disable the Doppler effect.</summary>
+        /// <param name="pSpatializer">Pointer to the spatializer.</param>
+        /// <param name="dopplerFactor">The Doppler factor. Set to 0 to disable.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_spatializer_set_doppler_factor(ma_spatializer_ptr pSpatializer, float dopplerFactor);
 
+        /// <summary>Retrieves the current Doppler factor of the spatializer.</summary>
+        /// <param name="pSpatializer">Pointer to the spatializer.</param>
+        /// <returns>The current Doppler factor.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_spatializer_get_doppler_factor(ma_spatializer_ptr pSpatializer);
 
+        /// <summary>Sets the directional attenuation factor for the spatializer. Set to 0 to disable directional attenuation.</summary>
+        /// <param name="pSpatializer">Pointer to the spatializer.</param>
+        /// <param name="directionalAttenuationFactor">The directional attenuation factor. Set to 0 to disable.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_spatializer_set_directional_attenuation_factor(ma_spatializer_ptr pSpatializer, float directionalAttenuationFactor);
 
+        /// <summary>Retrieves the current directional attenuation factor of the spatializer.</summary>
+        /// <param name="pSpatializer">Pointer to the spatializer.</param>
+        /// <returns>The current directional attenuation factor.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_spatializer_get_directional_attenuation_factor(ma_spatializer_ptr pSpatializer);
 
+        /// <summary>Sets the position of the spatializer in 3D space.</summary>
+        /// <param name="pSpatializer">Pointer to the spatializer.</param>
+        /// <param name="x">The X coordinate of the position.</param>
+        /// <param name="y">The Y coordinate of the position.</param>
+        /// <param name="z">The Z coordinate of the position.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_spatializer_set_position(ma_spatializer_ptr pSpatializer, float x, float y, float z);
 
+        /// <summary>Retrieves the current position of the spatializer.</summary>
+        /// <param name="pSpatializer">Pointer to the spatializer.</param>
+        /// <returns>A <see cref="ma_vec3f"/> containing the spatializer's position.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_vec3f ma_spatializer_get_position(ma_spatializer_ptr pSpatializer);
 
+        /// <summary>Sets the direction the spatializer is facing in 3D space.</summary>
+        /// <param name="pSpatializer">Pointer to the spatializer.</param>
+        /// <param name="x">The X component of the direction vector.</param>
+        /// <param name="y">The Y component of the direction vector.</param>
+        /// <param name="z">The Z component of the direction vector.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_spatializer_set_direction(ma_spatializer_ptr pSpatializer, float x, float y, float z);
 
+        /// <summary>Retrieves the current direction of the spatializer.</summary>
+        /// <param name="pSpatializer">Pointer to the spatializer.</param>
+        /// <returns>A <see cref="ma_vec3f"/> containing the spatializer's direction vector.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_vec3f ma_spatializer_get_direction(ma_spatializer_ptr pSpatializer);
 
+        /// <summary>Sets the velocity of the spatializer for Doppler effect calculation.</summary>
+        /// <param name="pSpatializer">Pointer to the spatializer.</param>
+        /// <param name="x">The X component of the velocity vector.</param>
+        /// <param name="y">The Y component of the velocity vector.</param>
+        /// <param name="z">The Z component of the velocity vector.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_spatializer_set_velocity(ma_spatializer_ptr pSpatializer, float x, float y, float z);
 
+        /// <summary>Retrieves the current velocity of the spatializer.</summary>
+        /// <param name="pSpatializer">Pointer to the spatializer.</param>
+        /// <returns>A <see cref="ma_vec3f"/> containing the spatializer's velocity vector.</returns>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_vec3f ma_spatializer_get_velocity(ma_spatializer_ptr pSpatializer);
 
+        /// <summary>Calculates the relative position and direction of the spatializer from a listener's perspective.</summary>
+        /// <param name="pSpatializer">Pointer to the spatializer.</param>
+        /// <param name="pListener">Pointer to the spatializer listener.</param>
+        /// <param name="pRelativePos">Receives the position of the spatializer relative to the listener.</param>
+        /// <param name="pRelativeDir">Receives the direction of the spatializer relative to the listener.</param>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_spatializer_get_relative_position_and_direction(ma_spatializer_ptr pSpatializer, ma_spatializer_listener_ptr pListener, out ma_vec3f pRelativePos, out ma_vec3f pRelativeDir);
 
         // ma_decoder
+        /// <summary>
+        /// Initializes a decoder config with the specified output format, channels, and sample rate.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_decoder_config ma_decoder_config_init(ma_format outputFormat, ma_uint32 outputChannels, ma_uint32 outputSampleRate);
 
+        /// <summary>
+        /// Initializes a decoder config with default settings.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_decoder_config ma_decoder_config_init_default();
 
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern ma_result ma_decoder_init(IntPtr onRead, IntPtr onSeek, IntPtr pUserData, ref ma_decoder_config pConfig, ma_decoder_ptr pDecoder);
 
+        /// <summary>
+        /// Initializes a decoder from custom read and seek callbacks.
+        /// </summary>
         public static ma_result ma_decoder_init(ma_decoder_read_proc onRead, ma_decoder_seek_proc onSeek, IntPtr pUserData, ref ma_decoder_config pConfig, ma_decoder_ptr pDecoder)
         {
             return ma_decoder_init(MarshalHelper.GetFunctionPointerForDelegate(onRead), MarshalHelper.GetFunctionPointerForDelegate(onSeek), pUserData, ref pConfig, pDecoder);
         }
 
+        /// <summary>
+        /// Initializes a decoder from a block of memory containing encoded audio data.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_decoder_init_memory(IntPtr pData, size_t dataSize, ref ma_decoder_config pConfig, ma_decoder_ptr pDecoder);
 
+        /// <summary>
+        /// Initializes a decoder from memory using default config settings.
+        /// </summary>
         public static ma_result ma_decoder_init_memory(IntPtr pData, size_t dataSize, ma_decoder_ptr pDecoder)
         {
             ma_decoder_config config = ma_decoder_config_init_default();
             return ma_decoder_init_memory(pData, dataSize, ref config, pDecoder);
         }
 
+        /// <summary>
+        /// Initializes a decoder from a file using a custom virtual file system.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_decoder_init_vfs(ma_vfs_ptr pVFS, string pFilePath, ref ma_decoder_config pConfig, ma_decoder_ptr pDecoder);
 
+        /// <summary>
+        /// Initializes a decoder from a file using a custom virtual file system (wide string path).
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_decoder_init_vfs_w(ma_vfs_ptr pVFS, [MarshalAs(UnmanagedType.LPWStr)] string pFilePath, ref ma_decoder_config pConfig, ma_decoder_ptr pDecoder);
 
+        /// <summary>
+        /// Initializes a decoder from a file path with the specified config.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_decoder_init_file(string pFilePath, ref ma_decoder_config pConfig, ma_decoder_ptr pDecoder);
 
+        /// <summary>
+        /// Initializes a decoder from a file path using default config settings.
+        /// </summary>
         public static ma_result ma_decoder_init_file(string pFilePath, ma_decoder_ptr pDecoder)
         {
             ma_decoder_config config = ma_decoder_config_init_default();
             return ma_decoder_init_file(pFilePath, ref config, pDecoder);
         }
 
+        /// <summary>
+        /// Initializes a decoder from a file path with the specified config (wide string path).
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_decoder_init_file_w([MarshalAs(UnmanagedType.LPWStr)] string pFilePath, ref ma_decoder_config pConfig, ma_decoder_ptr pDecoder);
 
+        /// <summary>
+        /// Uninitializes a decoder and releases its resources.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_decoder_uninit(ma_decoder_ptr pDecoder);
 
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe ma_result ma_decoder_read_pcm_frames(ma_decoder_ptr pDecoder, IntPtr pFramesOut, ma_uint64 frameCount, ma_uint64* pFramesRead);
 
+        /// <summary>
+        /// Reads raw PCM frames from the decoder. Returns the number of frames actually read via pFramesRead.
+        /// </summary>
         public static ma_result ma_decoder_read_pcm_frames(ma_decoder_ptr pDecoder, IntPtr pFramesOut, ma_uint64 frameCount, IntPtr pFramesRead)
         {
             unsafe
@@ -1044,71 +2236,137 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Seeks the decoder to a specific PCM frame index.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_decoder_seek_to_pcm_frame(ma_decoder_ptr pDecoder, ma_uint64 frameIndex);
 
+        /// <summary>
+        /// Retrieves the data format of the decoder (format, channels, sample rate, and channel map).
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_decoder_get_data_format(ma_decoder_ptr pDecoder, out ma_format pFormat, out ma_uint32 pChannels, out ma_uint32 pSampleRate, ma_channel_ptr pChannelMap, size_t channelMapCap);
 
+        /// <summary>
+        /// Gets the current read cursor position in PCM frames.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_decoder_get_cursor_in_pcm_frames(ma_decoder_ptr pDecoder, out ma_uint64 pCursor);
 
+        /// <summary>
+        /// Gets the total length of the decoded audio in PCM frames.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_decoder_get_length_in_pcm_frames(ma_decoder_ptr pDecoder, out ma_uint64 pLength);
 
+        /// <summary>
+        /// Gets the number of available PCM frames that can be read without blocking.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_decoder_get_available_frames(ma_decoder_ptr pDecoder, out ma_uint64 pAvailableFrames);
 
+        /// <summary>
+        /// Decodes an entire file from a virtual file system into a single buffer of PCM frames.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_decode_from_vfs(ma_vfs_ptr pVFS, string pFilePath, ref ma_decoder_config pConfig, ref ma_uint64 pFrameCountOut, IntPtr ppPCMFramesOut);
 
+        /// <summary>
+        /// Decodes an entire file into a single buffer of PCM frames.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_decode_file(string pFilePath, ref ma_decoder_config pConfig, ref ma_uint64 pFrameCountOut, IntPtr ppPCMFramesOut);
 
+        /// <summary>
+        /// Decodes an entire block of memory containing encoded audio data into a single buffer of PCM frames.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_decode_memory(IntPtr pData, size_t dataSize, ref ma_decoder_config pConfig, ref ma_uint64 pFrameCountOut, IntPtr ppPCMFramesOut);
 
         // ma_resource_manager
+        /// <summary>
+        /// Initializes a resource manager config with default settings.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_resource_manager_config ma_resource_manager_config_init();
 
+        /// <summary>
+        /// Initializes a resource manager which manages decoding and loading of audio resources.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_resource_manager_init(ref ma_resource_manager_config pConfig, ma_resource_manager_ptr pResourceManager);
 
+        /// <summary>
+        /// Uninitializes a resource manager and releases all associated resources.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_resource_manager_uninit(ma_resource_manager_ptr pResourceManager);
 
+        /// <summary>
+        /// Gets the log object associated with the resource manager.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_log_ptr ma_resource_manager_get_log(ma_resource_manager_ptr pResourceManager);
 
         // ma_gainer
+        /// <summary>
+        /// Initializes a gainer config with the specified channel count and smooth time in frames.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_gainer_config ma_gainer_config_init(ma_uint32 channels, ma_uint32 smoothTimeInFrames);
 
+        /// <summary>
+        /// Calculates the heap size required for a gainer.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_gainer_get_heap_size(ref ma_gainer_config pConfig, out size_t pHeapSizeInBytes);
 
+        /// <summary>
+        /// Initializes a gainer with a pre-allocated heap buffer.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_gainer_init_preallocated(ref ma_gainer_config pConfig, IntPtr pHeap, ma_gainer_ptr pGainer);
 
+        /// <summary>
+        /// Initializes a gainer which applies smooth gain adjustments to audio data.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_gainer_init(ref ma_gainer_config pConfig, IntPtr pAllocationCallbacks, ma_gainer_ptr pGainer);
 
+        /// <summary>
+        /// Uninitializes a gainer and releases its resources.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_gainer_uninit(ma_gainer_ptr pGainer, IntPtr pAllocationCallbacks);
 
+        /// <summary>
+        /// Processes PCM frames through the gainer, applying the configured gains.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_gainer_process_pcm_frames(ma_gainer_ptr pGainer, IntPtr pFramesOut, IntPtr pFramesIn, ma_uint64 frameCount);
 
+        /// <summary>
+        /// Sets the gain for all channels at once.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_gainer_set_gain(ma_gainer_ptr pGainer, float newGain);
 
+        /// <summary>
+        /// Sets individual gains for each channel.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_gainer_set_gains(ma_gainer_ptr pGainer, out float pNewGains);
 
+        /// <summary>
+        /// Sets the master volume of the gainer.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_gainer_set_master_volume(ma_gainer_ptr pGainer, float volume);
 
+        /// <summary>
+        /// Gets the current master volume of the gainer.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_gainer_get_master_volume(ma_gainer_ptr pGainer, out float pVolume);
 
@@ -1116,6 +2374,9 @@ namespace MiniAudioEx.Native
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static unsafe extern ma_decoding_backend_vtable* ma_libvorbis_get_decoding_backend();
 
+        /// <summary>
+        /// Retrieves a pointer to the libvorbis decoding backend vtable, which can be used with custom decoding backends.
+        /// </summary>
         public static ma_decoding_backend_vtable_ptr ma_libvorbis_get_decoding_backend_ptr()
         {
             unsafe
@@ -1128,6 +2389,9 @@ namespace MiniAudioEx.Native
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern ma_log_callback ma_log_callback_init(IntPtr onLog, IntPtr pUserData);
 
+        /// <summary>
+        /// Initializes a log callback with the specified callback function and user data.
+        /// </summary>
         public static ma_log_callback ma_log_callback_init(ma_log_callback_proc onLog, IntPtr pUserData)
         {
             return ma_log_callback_init(MarshalHelper.GetFunctionPointerForDelegate(onLog), pUserData);
@@ -1136,6 +2400,9 @@ namespace MiniAudioEx.Native
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe ma_result ma_log_init(ma_allocation_callbacks* pAllocationCallbacks, ma_log_ptr pLog);
 
+        /// <summary>
+        /// Initializes a log object with default allocation callbacks.
+        /// </summary>
         public static ma_result ma_log_init(ma_log_ptr pLog)
         {
             unsafe
@@ -1144,6 +2411,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Initializes a log object with custom allocation callbacks.
+        /// </summary>
         public static ma_result ma_log_init(ref ma_allocation_callbacks pAllocationCallbacks, ma_log_ptr pLog)
         {
             unsafe
@@ -1155,28 +2425,49 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Uninitializes a log object and releases its resources.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_log_uninit(ma_log_ptr pLog);
 
+        /// <summary>
+        /// Registers a callback function to receive log messages.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_log_register_callback(ma_log_ptr pLog, ma_log_callback callback);
 
+        /// <summary>
+        /// Unregisters a previously registered log callback.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_log_unregister_callback(ma_log_ptr pLog, ma_log_callback callback);
 
+        /// <summary>
+        /// Posts a message to the log at the specified log level.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_log_post(ma_log_ptr pLog, ma_uint32 level, string pMessage);
 
+        /// <summary>
+        /// Converts a log level integer value to its string representation.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern string ma_log_level_to_string(ma_uint32 logLevel);
 
         // ma_node_graph
+        /// <summary>
+        /// Initializes a node graph config with the specified number of channels.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_node_graph_config ma_node_graph_config_init(ma_uint32 channels);
 
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe ma_result ma_node_graph_init(ref ma_node_graph_config pConfig, ma_allocation_callbacks* pAllocationCallbacks, ma_node_graph_ptr pNodeGraph);
 
+        /// <summary>
+        /// Initializes a node graph with custom allocation callbacks. The node graph manages the processing graph of connected audio nodes.
+        /// </summary>
         public static ma_result ma_node_graph_init(ref ma_node_graph_config pConfig, ref ma_allocation_callbacks pAllocationCallbacks, ma_node_graph_ptr pNodeGraph)
         {
             unsafe
@@ -1188,6 +2479,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Initializes a node graph with default allocation callbacks.
+        /// </summary>
         public static ma_result ma_node_graph_init(ref ma_node_graph_config pConfig, ma_node_graph_ptr pNodeGraph)
         {
             unsafe
@@ -1199,6 +2493,9 @@ namespace MiniAudioEx.Native
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe void ma_node_graph_uninit(ma_node_graph_ptr pNodeGraph, ma_allocation_callbacks* pAllocationCallbacks);
 
+        /// <summary>
+        /// Uninitializes a node graph with custom allocation callbacks.
+        /// </summary>
         public static void ma_node_graph_uninit(ma_node_graph_ptr pNodeGraph, ref ma_allocation_callbacks pAllocationCallbacks)
         {
             unsafe
@@ -1210,6 +2507,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Uninitializes a node graph with default allocation callbacks.
+        /// </summary>
         public static void ma_node_graph_uninit(ma_node_graph_ptr pNodeGraph)
         {
             unsafe
@@ -1218,37 +2518,67 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Gets the endpoint node of the node graph, which is the final output node.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_node_ptr ma_node_graph_get_endpoint(ma_node_graph_ptr pNodeGraph);
 
+        /// <summary>
+        /// Reads PCM frames from the node graph, processing all connected nodes.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_node_graph_read_pcm_frames(ma_node_graph_ptr pNodeGraph, IntPtr pFramesOut, ma_uint64 frameCount, IntPtr pFramesRead);
 
+        /// <summary>
+        /// Gets the number of channels in the node graph.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_uint32 ma_node_graph_get_channels(ma_node_graph_ptr pNodeGraph);
 
+        /// <summary>
+        /// Gets the current global time of the node graph in PCM frames.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_uint64 ma_node_graph_get_time(ma_node_graph_ptr pNodeGraph);
 
+        /// <summary>
+        /// Sets the current global time of the node graph in PCM frames.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_node_graph_set_time(ma_node_graph_ptr pNodeGraph, ma_uint64 globalTime);
 
+        /// <summary>
+        /// Gets the processing size of the node graph in frames.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern UInt32 ma_node_graph_get_processing_size_in_frames(ma_node_graph_ptr pNodeGraph);
 
         // ma_node
+        /// <summary>
+        /// Initializes a node config with default settings.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_node_config ma_node_config_init();
 
+        /// <summary>
+        /// Gets the required heap size for a node with the given config.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_node_get_heap_size(ma_node_graph_ptr pNodeGraph, ref ma_node_config pConfig, out size_t pHeapSizeInBytes);
 
+        /// <summary>
+        /// Initializes a node with a pre-allocated heap buffer.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_node_init_preallocated(ma_node_graph_ptr pNodeGraph, ref ma_node_config pConfig, IntPtr pHeap, ma_node_ptr pNode);
 
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe ma_result ma_node_init(ma_node_graph_ptr pNodeGraph, ref ma_node_config pConfig, ma_allocation_callbacks* pAllocationCallbacks, ma_node_ptr pNode);
 
+        /// <summary>
+        /// Initializes a node within a node graph with custom allocation callbacks.
+        /// </summary>
         public static ma_result ma_node_init(ma_node_graph_ptr pNodeGraph, ref ma_node_config pConfig, ref ma_allocation_callbacks pAllocationCallbacks, ma_node_ptr pNode)
         {
             unsafe
@@ -1260,6 +2590,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Initializes a node within a node graph with default allocation callbacks.
+        /// </summary>
         public static ma_result ma_node_init(ma_node_graph_ptr pNodeGraph, ref ma_node_config pConfig, ma_node_ptr pNode)
         {
             unsafe
@@ -1271,6 +2604,9 @@ namespace MiniAudioEx.Native
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe void ma_node_uninit(ma_node_ptr pNode, ma_allocation_callbacks* pAllocationCallbacks);
 
+        /// <summary>
+        /// Uninitializes a node with custom allocation callbacks.
+        /// </summary>
         public static void ma_node_uninit(ma_node_ptr pNode, ref ma_allocation_callbacks pAllocationCallbacks)
         {
             unsafe
@@ -1282,6 +2618,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Uninitializes a node with default allocation callbacks.
+        /// </summary>
         public static void ma_node_uninit(ma_node_ptr pNode)
         {
             unsafe
@@ -1290,57 +2629,111 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Gets the node graph that this node belongs to.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_node_graph_ptr ma_node_get_node_graph(ma_node_ptr pNode);
 
+        /// <summary>
+        /// Gets the number of input buses on this node.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_uint32 ma_node_get_input_bus_count(ma_node_ptr pNode);
 
+        /// <summary>
+        /// Gets the number of output buses on this node.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_uint32 ma_node_get_output_bus_count(ma_node_ptr pNode);
 
+        /// <summary>
+        /// Gets the number of input channels for a specific input bus.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_uint32 ma_node_get_input_channels(ma_node_ptr pNode, ma_uint32 inputBusIndex);
 
+        /// <summary>
+        /// Gets the number of output channels for a specific output bus.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_uint32 ma_node_get_output_channels(ma_node_ptr pNode, ma_uint32 outputBusIndex);
 
+        /// <summary>
+        /// Attaches an output bus of this node to an input bus of another node.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_node_attach_output_bus(ma_node_ptr pNode, ma_uint32 outputBusIndex, ma_node_ptr pOtherNode, ma_uint32 otherNodeInputBusIndex);
 
+        /// <summary>
+        /// Detaches an output bus from whatever it is connected to.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_node_detach_output_bus(ma_node_ptr pNode, ma_uint32 outputBusIndex);
 
+        /// <summary>
+        /// Detaches all output buses on this node.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_node_detach_all_output_buses(ma_node_ptr pNode);
 
+        /// <summary>
+        /// Sets the volume of a specific output bus.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_node_set_output_bus_volume(ma_node_ptr pNode, ma_uint32 outputBusIndex, float volume);
 
+        /// <summary>
+        /// Gets the volume of a specific output bus.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_node_get_output_bus_volume(ma_node_ptr pNode, ma_uint32 outputBusIndex);
 
+        /// <summary>
+        /// Sets the state of this node (started, stopped, etc.).
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_node_set_state(ma_node_ptr pNode, ma_node_state state);
 
+        /// <summary>
+        /// Gets the current state of this node.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_node_state ma_node_get_state(ma_node_ptr pNode);
 
+        /// <summary>
+        /// Sets the state of this node to change at a specific global time.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_node_set_state_time(ma_node_ptr pNode, ma_node_state state, ma_uint64 globalTime);
 
+        /// <summary>
+        /// Gets the time at which the node last entered the given state.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_uint64 ma_node_get_state_time(ma_node_ptr pNode, ma_node_state state);
 
+        /// <summary>
+        /// Gets the state of the node at a specific global time.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_node_state ma_node_get_state_by_time(ma_node_ptr pNode, ma_uint64 globalTime);
 
+        /// <summary>
+        /// Gets the state of the node within a time range. Returns the most significant state.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_node_state ma_node_get_state_by_time_range(ma_node_ptr pNode, ma_uint64 globalTimeBeg, ma_uint64 globalTimeEnd);
 
+        /// <summary>
+        /// Gets the local time of the node in PCM frames.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_uint64 ma_node_get_time(ma_node_ptr pNode);
 
+        /// <summary>
+        /// Sets the local time of the node in PCM frames.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_node_set_time(ma_node_ptr pNode, ma_uint64 localTime);
 
@@ -1348,6 +2741,9 @@ namespace MiniAudioEx.Native
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_effect_node_config ma_effect_node_config_init(ma_uint32 channels, ma_uint32 sampleRate, IntPtr onProcess, IntPtr pUserData);
 
+        /// <summary>
+        /// Initializes an effect node config with the specified channels, sample rate, and custom processing callback.
+        /// </summary>
         public static ma_effect_node_config ma_effect_node_config_init(ma_uint32 channels, ma_uint32 sampleRate, ma_effect_node_process_proc onProcess, IntPtr pUserData)
         {
             return ma_effect_node_config_init(channels, sampleRate, MarshalHelper.GetFunctionPointerForDelegate(onProcess), pUserData);
@@ -1356,6 +2752,9 @@ namespace MiniAudioEx.Native
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe ma_result ma_effect_node_init(ma_node_graph_ptr pNodeGraph, ref ma_effect_node_config pConfig, ma_allocation_callbacks* pAllocationCallbacks, ma_effect_node_ptr pEffectNode);
 
+        /// <summary>
+        /// Initializes an effect node within a node graph. The effect node uses a custom callback for audio processing.
+        /// </summary>
         public static ma_result ma_effect_node_init(ma_node_graph_ptr pNodeGraph, ref ma_effect_node_config pConfig, ma_effect_node_ptr pEffectNode)
         {
             unsafe
@@ -1367,6 +2766,9 @@ namespace MiniAudioEx.Native
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe void ma_effect_node_uninit(ma_effect_node_ptr pEffectNode, ma_allocation_callbacks* pAllocationCallbacks);
 
+        /// <summary>
+        /// Uninitializes an effect node and releases its resources.
+        /// </summary>
         public static void ma_effect_node_uninit(ma_effect_node_ptr pEffectNode)
         {
             unsafe
@@ -1376,87 +2778,168 @@ namespace MiniAudioEx.Native
         }
 
         // ma_data_source
+        /// <summary>
+        /// Initializes a data source config with default settings.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_data_source_config ma_data_source_config_init();
 
+        /// <summary>
+        /// Initializes a data source. A data source is the base abstraction for any object that produces audio data.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_data_source_init(ref ma_data_source_config pConfig, ma_data_source_ptr pDataSource);
 
+        /// <summary>
+        /// Uninitializes a data source and releases its resources.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_data_source_uninit(ma_data_source_ptr pDataSource);
 
+        /// <summary>
+        /// Reads PCM frames from the data source.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_data_source_read_pcm_frames(ma_data_source_ptr pDataSource, IntPtr pFramesOut, ma_uint64 frameCount, IntPtr pFramesRead);
 
+        /// <summary>
+        /// Seeks forward by a number of PCM frames.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_data_source_seek_pcm_frames(ma_data_source_ptr pDataSource, ma_uint64 frameCount, out ma_uint64 pFramesSeeked);
 
+        /// <summary>
+        /// Seeks to a specific PCM frame index.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_data_source_seek_to_pcm_frame(ma_data_source_ptr pDataSource, ma_uint64 frameIndex);
 
+        /// <summary>
+        /// Seeks forward by a number of seconds.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_data_source_seek_seconds(ma_data_source_ptr pDataSource, float secondCount, out float pSecondsSeeked);
 
+        /// <summary>
+        /// Seeks to a specific point in seconds.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_data_source_seek_to_second(ma_data_source_ptr pDataSource, float seekPointInSeconds);
 
+        /// <summary>
+        /// Retrieves the data format of the data source.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_data_source_get_data_format(ma_data_source_ptr pDataSource, out ma_format pFormat, out ma_uint32 pChannels, out ma_uint32 pSampleRate, ma_channel_ptr pChannelMap, size_t channelMapCap);
 
+        /// <summary>
+        /// Gets the current cursor position in PCM frames.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_data_source_get_cursor_in_pcm_frames(ma_data_source_ptr pDataSource, out ma_uint64 pCursor);
 
+        /// <summary>
+        /// Gets the total length of the data source in PCM frames.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_data_source_get_length_in_pcm_frames(ma_data_source_ptr pDataSource, out ma_uint64 pLength);
 
+        /// <summary>
+        /// Gets the current cursor position in seconds.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_data_source_get_cursor_in_seconds(ma_data_source_ptr pDataSource, out float pCursor);
 
+        /// <summary>
+        /// Gets the total length of the data source in seconds.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_data_source_get_length_in_seconds(ma_data_source_ptr pDataSource, out float pLength);
 
+        /// <summary>
+        /// Sets whether the data source should loop when it reaches the end.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_data_source_set_looping(ma_data_source_ptr pDataSource, ma_bool32 isLooping);
 
+        /// <summary>
+        /// Returns whether the data source is currently set to loop.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_bool32 ma_data_source_is_looping(ma_data_source_ptr pDataSource);
 
+        /// <summary>
+        /// Sets the playback range in PCM frames.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_data_source_set_range_in_pcm_frames(ma_data_source_ptr pDataSource, ma_uint64 rangeBegInFrames, ma_uint64 rangeEndInFrames);
 
+        /// <summary>
+        /// Gets the current playback range in PCM frames.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_data_source_get_range_in_pcm_frames(ma_data_source_ptr pDataSource, out ma_uint64 pRangeBegInFrames, out ma_uint64 pRangeEndInFrames);
 
+        /// <summary>
+        /// Sets the loop point boundaries in PCM frames.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_data_source_set_loop_point_in_pcm_frames(ma_data_source_ptr pDataSource, ma_uint64 loopBegInFrames, ma_uint64 loopEndInFrames);
 
+        /// <summary>
+        /// Gets the current loop point boundaries in PCM frames.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_data_source_get_loop_point_in_pcm_frames(ma_data_source_ptr pDataSource, out ma_uint64 pLoopBegInFrames, out ma_uint64 pLoopEndInFrames);
 
+        /// <summary>
+        /// Sets the current child data source for chained playback.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_data_source_set_current(ma_data_source_ptr pDataSource, ma_data_source_ptr pCurrentDataSource);
 
+        /// <summary>
+        /// Gets the current child data source.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_data_source_ptr ma_data_source_get_current(ma_data_source_ptr pDataSource);
 
+        /// <summary>
+        /// Sets the next data source to play after the current one finishes.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_data_source_set_next(ma_data_source_ptr pDataSource, ma_data_source_ptr pNextDataSource);
 
+        /// <summary>
+        /// Gets the next data source in the chain.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_data_source_ptr ma_data_source_get_next(ma_data_source_ptr pDataSource);
 
+        /// <summary>
+        /// Sets a callback to dynamically determine the next data source.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_data_source_set_next_callback(ma_data_source_ptr pDataSource, ma_data_source_get_next_proc onGetNext);
 
+        /// <summary>
+        /// Gets the currently set next callback.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_data_source_get_next_proc ma_data_source_get_next_callback(ma_data_source_ptr pDataSource);
 
+        /// <summary>
+        /// Initializes a data source node config with the specified data source.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_data_source_node_config ma_data_source_node_config_init(ma_data_source_ptr pDataSource);
 
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe ma_result ma_data_source_node_init(ma_node_graph_ptr pNodeGraph, ref ma_data_source_node_config pConfig, ma_allocation_callbacks* pAllocationCallbacks, ma_data_source_node_ptr pDataSourceNode);
 
+        /// <summary>
+        /// Initializes a data source node with custom allocation callbacks. Wraps a data source as a node in the audio graph.
+        /// </summary>
         public static ma_result ma_data_source_node_init(ma_node_graph_ptr pNodeGraph, ref ma_data_source_node_config pConfig, ref ma_allocation_callbacks pAllocationCallbacks, ma_data_source_node_ptr pDataSourceNode)
         {
             unsafe
@@ -1468,6 +2951,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Initializes a data source node with default allocation callbacks.
+        /// </summary>
         public static ma_result ma_data_source_node_init(ma_node_graph_ptr pNodeGraph, ref ma_data_source_node_config pConfig, ma_data_source_node_ptr pDataSourceNode)
         {
             unsafe
@@ -1479,6 +2965,9 @@ namespace MiniAudioEx.Native
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe void ma_data_source_node_uninit(ma_data_source_node_ptr pDataSourceNode, ma_allocation_callbacks* pAllocationCallbacks);
 
+        /// <summary>
+        /// Uninitializes a data source node with custom allocation callbacks.
+        /// </summary>
         public static void ma_data_source_node_uninit(ma_data_source_node_ptr pDataSourceNode, ref ma_allocation_callbacks pAllocationCallbacks)
         {
             unsafe
@@ -1490,6 +2979,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Uninitializes a data source node with default allocation callbacks.
+        /// </summary>
         public static unsafe void ma_data_source_node_uninit(ma_data_source_node_ptr pDataSourceNode)
         {
             unsafe
@@ -1498,133 +2990,250 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Sets whether the data source node should loop.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_data_source_node_set_looping(ma_data_source_node_ptr pDataSourceNode, ma_bool32 isLooping);
 
+        /// <summary>
+        /// Returns whether the data source node is currently looping.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_bool32 ma_data_source_node_is_looping(ma_data_source_node_ptr pDataSourceNode);
 
         // ma_fader
+        /// <summary>
+        /// Initializes a fader config with the specified format, channels, and sample rate.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_fader_config ma_fader_config_init(ma_format format, ma_uint32 channels, ma_uint32 sampleRate);
 
+        /// <summary>
+        /// Initializes a fader which applies smooth volume fading over time.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_fader_init(ref ma_fader_config pConfig, ma_fader_ptr pFader);
 
+        /// <summary>
+        /// Processes PCM frames through the fader, applying the current fade volume.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_fader_process_pcm_frames(ma_fader_ptr pFader, IntPtr pFramesOut, IntPtr pFramesIn, ma_uint64 frameCount);
 
+        /// <summary>
+        /// Gets the data format of the fader.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_fader_get_data_format(ma_fader_ptr pFader, out ma_format pFormat, out ma_uint32 pChannels, out ma_uint32 pSampleRate);
 
+        /// <summary>
+        /// Sets a volume fade from volumeBeg to volumeEnd over the specified length in frames.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_fader_set_fade(ma_fader_ptr pFader, float volumeBeg, float volumeEnd, ma_uint64 lengthInFrames);
 
+        /// <summary>
+        /// Sets a volume fade with an additional start offset in frames.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_fader_set_fade_ex(ma_fader_ptr pFader, float volumeBeg, float volumeEnd, ma_uint64 lengthInFrames, ma_int64 startOffsetInFrames);
 
+        /// <summary>
+        /// Gets the current volume of the fader.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_fader_get_current_volume(ma_fader_ptr pFader);
 
         // ma_panner
+        /// <summary>
+        /// Initializes a panner config with the specified format and channels.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_panner_config ma_panner_config_init(ma_format format, ma_uint32 channels);
 
+        /// <summary>
+        /// Initializes a panner which applies panning to audio data.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_panner_init(ref ma_panner_config pConfig, ma_panner_ptr pPanner);
 
+        /// <summary>
+        /// Processes PCM frames through the panner, applying the current pan settings.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_panner_process_pcm_frames(ma_panner_ptr pPanner, IntPtr pFramesOut, IntPtr pFramesIn, ma_uint64 frameCount);
 
+        /// <summary>
+        /// Sets the panning mode (e.g., balance, panning law).
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_panner_set_mode(ma_panner_ptr pPanner, ma_pan_mode mode);
 
+        /// <summary>
+        /// Gets the current panning mode.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_pan_mode ma_panner_get_mode(ma_panner_ptr pPanner);
 
+        /// <summary>
+        /// Sets the pan position. -1 is left, 0 is center, +1 is right.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_panner_set_pan(ma_panner_ptr pPanner, float pan);
 
+        /// <summary>
+        /// Gets the current pan position.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_panner_get_pan(ma_panner_ptr pPanner);
 
         // ma_channel_map
+        /// <summary>
+        /// Gets the channel position at the specified index within a channel map.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_channel ma_channel_map_get_channel(ma_channel_ptr pChannelMap, ma_uint32 channelCount, ma_uint32 channelIndex);
 
+        /// <summary>
+        /// Initializes a channel map with blank (unspecified) channel positions.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_channel_map_init_blank(ma_channel_ptr pChannelMap, ma_uint32 channels);
 
+        /// <summary>
+        /// Initializes a channel map with a standard layout (e.g., mono, stereo, 5.1, 7.1).
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_channel_map_init_standard(ma_standard_channel_map standardChannelMap, ma_channel_ptr pChannelMap, size_t channelMapCap, ma_uint32 channels);
 
+        /// <summary>
+        /// Copies a channel map from source to destination.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_channel_map_copy(ma_channel_ptr pOut, ma_channel_ptr pIn, ma_uint32 channels);
 
+        /// <summary>
+        /// Copies a channel map, falling back to a default layout if the source is invalid.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_channel_map_copy_or_default(ma_channel_ptr pOut, size_t channelMapCapOut, ma_channel_ptr pIn, ma_uint32 channels);
 
+        /// <summary>
+        /// Returns whether the channel map is valid (all channels have valid positions).
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_bool32 ma_channel_map_is_valid(ma_channel_ptr pChannelMap, ma_uint32 channels);
 
+        /// <summary>
+        /// Returns whether two channel maps are equal.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_bool32 ma_channel_map_is_equal(ma_channel_ptr pChannelMapA, ma_channel_ptr pChannelMapB, ma_uint32 channels);
 
+        /// <summary>
+        /// Returns whether the channel map is blank (all channels are unspecified).
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_bool32 ma_channel_map_is_blank(ma_channel_ptr pChannelMap, ma_uint32 channels);
 
+        /// <summary>
+        /// Checks if a channel map contains a specific channel position.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_bool32 ma_channel_map_contains_channel_position(ma_uint32 channels, ma_channel_ptr pChannelMap, ma_channel channelPosition);
 
+        /// <summary>
+        /// Finds the index of a specific channel position within the channel map.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_bool32 ma_channel_map_find_channel_position(ma_uint32 channels, ma_channel_ptr pChannelMap, ma_channel channelPosition, out ma_uint32 pChannelIndex);
 
+        /// <summary>
+        /// Converts a channel map to its string representation (e.g., "FL FR").
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern size_t ma_channel_map_to_string(ma_channel_ptr pChannelMap, ma_uint32 channels, IntPtr pBufferOut, size_t bufferCap);
 
         // ma_encoder
+        /// <summary>
+        /// Initializes an encoder config with the specified encoding format, sample format, channels, and sample rate.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_encoder_config ma_encoder_config_init(ma_encoding_format encodingFormat, ma_format format, ma_uint32 channels, ma_uint32 sampleRate);
 
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern ma_result ma_encoder_init(IntPtr onWrite, IntPtr onSeek, IntPtr pUserData, ref ma_encoder_config pConfig, ma_encoder_ptr pEncoder);
 
+        /// <summary>
+        /// Initializes an encoder with custom write and seek callbacks.
+        /// </summary>
         public static ma_result ma_encoder_init(ma_encoder_write_proc onWrite, ma_encoder_seek_proc onSeek, IntPtr pUserData, ref ma_encoder_config pConfig, ma_encoder_ptr pEncoder)
         {
             return ma_encoder_init(MarshalHelper.GetFunctionPointerForDelegate(onWrite), MarshalHelper.GetFunctionPointerForDelegate(onWrite), pUserData, ref pConfig, pEncoder);
         }
 
+        /// <summary>
+        /// Initializes an encoder writing to a file using a custom virtual file system.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_encoder_init_vfs(ma_vfs pVFS, string pFilePath, ref ma_encoder_config pConfig, ma_encoder_ptr pEncoder);
 
+        /// <summary>
+        /// Initializes an encoder writing to a file using a custom virtual file system (wide string path).
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_encoder_init_vfs_w(ma_vfs pVFS, [MarshalAs(UnmanagedType.LPWStr)] string pFilePath, ref ma_encoder_config pConfig, ma_encoder_ptr pEncoder);
 
+        /// <summary>
+        /// Initializes an encoder writing to a file path.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_encoder_init_file(string pFilePath, ref ma_encoder_config pConfig, ma_encoder_ptr pEncoder);
 
+        /// <summary>
+        /// Initializes an encoder writing to a file path (wide string path).
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_encoder_init_file_w([MarshalAs(UnmanagedType.LPWStr)] string pFilePath, ref ma_encoder_config pConfig, ma_encoder_ptr pEncoder);
 
+        /// <summary>
+        /// Uninitializes an encoder and releases its resources.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_encoder_uninit(ma_encoder_ptr pEncoder);
 
+        /// <summary>
+        /// Writes PCM frames to the encoder for encoding.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_encoder_write_pcm_frames(ma_encoder_ptr pEncoder, IntPtr pFramesIn, ma_uint64 frameCount, out ma_uint64 pFramesWritten);
 
         // ma_biquad/filters general
+        /// <summary>
+        /// Initializes a biquad filter config with the specified coefficients.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_biquad_config ma_biquad_config_init(ma_format format, UInt32 channels, double b0, double b1, double b2, double a0, double a1, double a2);
         
+        /// <summary>
+        /// Calculates the heap size required for a biquad filter.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_biquad_get_heap_size(ref ma_biquad_config pConfig, out size_t pHeapSizeInBytes);
         
+        /// <summary>
+        /// Initializes a biquad filter with a pre-allocated heap buffer.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_biquad_init_preallocated(ref ma_biquad_config pConfig, IntPtr pHeap, ma_biquad_ptr pBQ);
         
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe ma_result ma_biquad_init(ref ma_biquad_config pConfig, ma_allocation_callbacks* pAllocationCallbacks, ma_biquad_ptr pBQ);
 
+        /// <summary>
+        /// Initializes a biquad filter with custom allocation callbacks.
+        /// </summary>
         public static ma_result ma_biquad_init(ref ma_biquad_config pConfig, ref ma_allocation_callbacks pAllocationCallbacks, ma_biquad_ptr pBQ)
         {
             unsafe
@@ -1636,6 +3245,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Initializes a biquad filter with default allocation callbacks.
+        /// </summary>
         public static ma_result ma_biquad_init(ref ma_biquad_config pConfig, ma_biquad_ptr pBQ)
         {
             unsafe
@@ -1647,6 +3259,9 @@ namespace MiniAudioEx.Native
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe void ma_biquad_uninit(ma_biquad_ptr pBQ, ma_allocation_callbacks* pAllocationCallbacks);
 
+        /// <summary>
+        /// Uninitializes a biquad filter with custom allocation callbacks.
+        /// </summary>
         public static void ma_biquad_uninit(ma_biquad_ptr pBQ, ref ma_allocation_callbacks pAllocationCallbacks)
         {
             unsafe
@@ -1658,6 +3273,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Uninitializes a biquad filter with default allocation callbacks.
+        /// </summary>
         public static void ma_biquad_uninit(ma_biquad_ptr pBQ)
         {
             unsafe
@@ -1666,33 +3284,60 @@ namespace MiniAudioEx.Native
             }
         }
         
+        /// <summary>
+        /// Reinitializes a biquad filter with a new config.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_biquad_reinit(ref ma_biquad_config pConfig, ma_biquad_ptr pBQ);
         
+        /// <summary>
+        /// Clears the internal state (delay buffer) of the biquad filter.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_biquad_clear_cache(ma_biquad_ptr pBQ);
         
+        /// <summary>
+        /// Processes PCM frames through the biquad filter.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_biquad_process_pcm_frames(ma_biquad_ptr pBQ, IntPtr pFramesOut, IntPtr pFramesIn, UInt64 frameCount);
         
+        /// <summary>
+        /// Gets the latency of the biquad filter in frames.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern UInt32 ma_biquad_get_latency(ma_biquad_ptr pBQ);
         
+        /// <summary>
+        /// Initializes a first-order low-pass filter config.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_lpf1_config ma_lpf1_config_init(ma_format format, UInt32 channels, UInt32 sampleRate, double cutoffFrequency);
         
+        /// <summary>
+        /// Initializes a second-order low-pass filter config.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_lpf2_config ma_lpf2_config_init(ma_format format, UInt32 channels, UInt32 sampleRate, double cutoffFrequency, double q);
         
+        /// <summary>
+        /// Calculates the heap size required for a first-order low-pass filter.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_lpf1_get_heap_size(ref ma_lpf1_config pConfig, out size_t pHeapSizeInBytes);
         
+        /// <summary>
+        /// Initializes a first-order low-pass filter with a pre-allocated heap buffer.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_lpf1_init_preallocated(ref ma_lpf1_config pConfig, IntPtr pHeap, ma_lpf1_ptr pLPF);
         
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe ma_result ma_lpf1_init(ref ma_lpf1_config pConfig, ma_allocation_callbacks* pAllocationCallbacks, ma_lpf1_ptr pLPF);
 
+        /// <summary>
+        /// Initializes a first-order low-pass filter with custom allocation callbacks.
+        /// </summary>
         public static ma_result ma_lpf1_init(ref ma_lpf1_config pConfig, ref ma_allocation_callbacks pAllocationCallbacks, ma_lpf1_ptr pLPF)
         {
             unsafe
@@ -1704,6 +3349,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Initializes a first-order low-pass filter with default allocation callbacks.
+        /// </summary>
         public static ma_result ma_lpf1_init(ref ma_lpf1_config pConfig, ma_lpf1_ptr pLPF)
         {
             unsafe
@@ -1715,6 +3363,9 @@ namespace MiniAudioEx.Native
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe void ma_lpf1_uninit(ma_lpf1_ptr pLPF, ma_allocation_callbacks* pAllocationCallbacks);
 
+        /// <summary>
+        /// Uninitializes a first-order low-pass filter with custom allocation callbacks.
+        /// </summary>
         public static void ma_lpf1_uninit(ma_lpf1_ptr pLPF, ref ma_allocation_callbacks pAllocationCallbacks)
         {
             unsafe
@@ -1726,6 +3377,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Uninitializes a first-order low-pass filter with default allocation callbacks.
+        /// </summary>
         public static void ma_lpf1_uninit(ma_lpf1_ptr pLPF)
         {
             unsafe
@@ -1734,27 +3388,48 @@ namespace MiniAudioEx.Native
             }
         }
         
+        /// <summary>
+        /// Reinitializes a first-order low-pass filter with a new config.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_lpf1_reinit(ref ma_lpf1_config pConfig, ma_lpf1_ptr pLPF);
         
+        /// <summary>
+        /// Clears the internal state of the first-order low-pass filter.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_lpf1_clear_cache(ma_lpf1_ptr pLPF);
         
+        /// <summary>
+        /// Processes PCM frames through the first-order low-pass filter.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_lpf1_process_pcm_frames(ma_lpf1_ptr pLPF, IntPtr pFramesOut, IntPtr pFramesIn, UInt64 frameCount);
         
+        /// <summary>
+        /// Gets the latency of the first-order low-pass filter in frames.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern UInt32 ma_lpf1_get_latency(ma_lpf1_ptr pLPF);
         
+        /// <summary>
+        /// Calculates the heap size required for a second-order low-pass filter.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_lpf2_get_heap_size(ref ma_lpf2_config pConfig, out size_t pHeapSizeInBytes);
         
+        /// <summary>
+        /// Initializes a second-order low-pass filter with a pre-allocated heap buffer.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_lpf2_init_preallocated(ref ma_lpf2_config pConfig, IntPtr pHeap, ma_lpf2_ptr pHPF);
         
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe ma_result ma_lpf2_init(ref ma_lpf2_config pConfig, ma_allocation_callbacks* pAllocationCallbacks, ma_lpf2_ptr pLPF);
 
+        /// <summary>
+        /// Initializes a second-order low-pass filter with custom allocation callbacks.
+        /// </summary>
         public static ma_result ma_lpf2_init(ref ma_lpf2_config pConfig, ref ma_allocation_callbacks pAllocationCallbacks, ma_lpf2_ptr pLPF)
         {
             unsafe
@@ -1766,6 +3441,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Initializes a second-order low-pass filter with default allocation callbacks.
+        /// </summary>
         public static ma_result ma_lpf2_init(ref ma_lpf2_config pConfig, ma_lpf2_ptr pLPF)
         {
             unsafe
@@ -1777,6 +3455,9 @@ namespace MiniAudioEx.Native
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe void ma_lpf2_uninit(ma_lpf2_ptr pLPF, ma_allocation_callbacks* pAllocationCallbacks);
 
+        /// <summary>
+        /// Uninitializes a second-order low-pass filter with custom allocation callbacks.
+        /// </summary>
         public static void ma_lpf2_uninit(ma_lpf2_ptr pLPF, ref ma_allocation_callbacks pAllocationCallbacks)
         {
             unsafe
@@ -1788,6 +3469,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Uninitializes a second-order low-pass filter with default allocation callbacks.
+        /// </summary>
         public static void ma_lpf2_uninit(ma_lpf2_ptr pLPF)
         {
             unsafe
@@ -1796,30 +3480,54 @@ namespace MiniAudioEx.Native
             }
         }
         
+        /// <summary>
+        /// Reinitializes a second-order low-pass filter with a new config.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_lpf2_reinit(ref ma_lpf2_config pConfig, ma_lpf2_ptr pLPF);
         
+        /// <summary>
+        /// Clears the internal state of the second-order low-pass filter.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_lpf2_clear_cache(ma_lpf2_ptr pLPF);
         
+        /// <summary>
+        /// Processes PCM frames through the second-order low-pass filter.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_lpf2_process_pcm_frames(ma_lpf2_ptr pLPF, IntPtr pFramesOut, IntPtr pFramesIn, UInt64 frameCount);
         
+        /// <summary>
+        /// Gets the latency of the second-order low-pass filter in frames.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern UInt32 ma_lpf2_get_latency(ma_lpf2_ptr pLPF);
         
+        /// <summary>
+        /// Initializes a configurable-order low-pass filter config.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_lpf_config ma_lpf_config_init(ma_format format, UInt32 channels, UInt32 sampleRate, double cutoffFrequency, UInt32 order);
         
+        /// <summary>
+        /// Calculates the heap size required for a configurable-order low-pass filter.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_lpf_get_heap_size(ref ma_lpf_config pConfig, out size_t pHeapSizeInBytes);
         
+        /// <summary>
+        /// Initializes a configurable-order low-pass filter with a pre-allocated heap buffer.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_lpf_init_preallocated(ref ma_lpf_config pConfig, IntPtr pHeap, ma_lpf_ptr pLPF);
         
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe ma_result ma_lpf_init(ref ma_lpf_config pConfig, ma_allocation_callbacks* pAllocationCallbacks, ma_lpf_ptr pLPF);
 
+        /// <summary>
+        /// Initializes a configurable-order low-pass filter with custom allocation callbacks.
+        /// </summary>
         public static ma_result ma_lpf_init(ref ma_lpf_config pConfig, ref ma_allocation_callbacks pAllocationCallbacks, ma_lpf_ptr pLPF)
         {
             unsafe
@@ -1831,6 +3539,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Initializes a configurable-order low-pass filter with default allocation callbacks.
+        /// </summary>
         public static ma_result ma_lpf_init(ref ma_lpf_config pConfig, ma_lpf_ptr pLPF)
         {
             unsafe
@@ -1842,6 +3553,9 @@ namespace MiniAudioEx.Native
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe void ma_lpf_uninit(ma_lpf_ptr pLPF, ma_allocation_callbacks* pAllocationCallbacks);
 
+        /// <summary>
+        /// Uninitializes a configurable-order low-pass filter with custom allocation callbacks.
+        /// </summary>
         public static void ma_lpf_uninit(ma_lpf_ptr pLPF, ref ma_allocation_callbacks pAllocationCallbacks)
         {
             unsafe
@@ -1853,6 +3567,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Uninitializes a configurable-order low-pass filter with default allocation callbacks.
+        /// </summary>
         public static void ma_lpf_uninit(ma_lpf_ptr pLPF)
         {
             unsafe
@@ -1861,33 +3578,60 @@ namespace MiniAudioEx.Native
             }
         }
         
+        /// <summary>
+        /// Reinitializes a configurable-order low-pass filter with a new config.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_lpf_reinit(ref ma_lpf_config pConfig, ma_lpf_ptr pLPF);
         
+        /// <summary>
+        /// Clears the internal state of the configurable-order low-pass filter.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_lpf_clear_cache(ma_lpf_ptr pLPF);
         
+        /// <summary>
+        /// Processes PCM frames through the configurable-order low-pass filter.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_lpf_process_pcm_frames(ma_lpf_ptr pLPF, IntPtr pFramesOut, IntPtr pFramesIn, UInt64 frameCount);
         
+        /// <summary>
+        /// Gets the latency of the configurable-order low-pass filter in frames.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern UInt32 ma_lpf_get_latency(ma_lpf_ptr pLPF);
         
+        /// <summary>
+        /// Initializes a first-order high-pass filter config.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_hpf1_config ma_hpf1_config_init(ma_format format, UInt32 channels, UInt32 sampleRate, double cutoffFrequency);
         
+        /// <summary>
+        /// Initializes a second-order high-pass filter config.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_hpf2_config ma_hpf2_config_init(ma_format format, UInt32 channels, UInt32 sampleRate, double cutoffFrequency, double q);
         
+        /// <summary>
+        /// Calculates the heap size required for a first-order high-pass filter.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_hpf1_get_heap_size(ref ma_hpf1_config pConfig, out size_t pHeapSizeInBytes);
         
+        /// <summary>
+        /// Initializes a first-order high-pass filter with a pre-allocated heap buffer.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_hpf1_init_preallocated(ref ma_hpf1_config pConfig, IntPtr pHeap, ma_hpf1_ptr pLPF);
         
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe ma_result ma_hpf1_init(ref ma_hpf1_config pConfig, ma_allocation_callbacks* pAllocationCallbacks, ma_hpf1_ptr pHPF);
 
+        /// <summary>
+        /// Initializes a first-order high-pass filter with custom allocation callbacks.
+        /// </summary>
         public static ma_result ma_hpf1_init(ref ma_hpf1_config pConfig, ref ma_allocation_callbacks pAllocationCallbacks, ma_hpf1_ptr pHPF)
         {
             unsafe
@@ -1899,6 +3643,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Initializes a first-order high-pass filter with default allocation callbacks.
+        /// </summary>
         public static ma_result ma_hpf1_init(ref ma_hpf1_config pConfig, ma_hpf1_ptr pHPF)
         {
             unsafe
@@ -1910,6 +3657,9 @@ namespace MiniAudioEx.Native
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe void ma_hpf1_uninit(ma_hpf1_ptr pHPF, ma_allocation_callbacks* pAllocationCallbacks);
 
+        /// <summary>
+        /// Uninitializes a first-order high-pass filter with custom allocation callbacks.
+        /// </summary>
         public static void ma_hpf1_uninit(ma_hpf1_ptr pHPF, ref ma_allocation_callbacks pAllocationCallbacks)
         {
             unsafe
@@ -1921,6 +3671,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Uninitializes a first-order high-pass filter with default allocation callbacks.
+        /// </summary>
         public static void ma_hpf1_uninit(ma_hpf1_ptr pHPF)
         {
             unsafe
@@ -1929,24 +3682,42 @@ namespace MiniAudioEx.Native
             }
         }
         
+        /// <summary>
+        /// Reinitializes a first-order high-pass filter with a new config.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_hpf1_reinit(ref ma_hpf1_config pConfig, ma_hpf1_ptr pHPF);
         
+        /// <summary>
+        /// Processes PCM frames through the first-order high-pass filter.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_hpf1_process_pcm_frames(ma_hpf1_ptr pHPF, IntPtr pFramesOut, IntPtr pFramesIn, UInt64 frameCount);
         
+        /// <summary>
+        /// Gets the latency of the first-order high-pass filter in frames.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern UInt32 ma_hpf1_get_latency(ma_hpf1_ptr pHPF);
         
+        /// <summary>
+        /// Calculates the heap size required for a second-order high-pass filter.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_hpf2_get_heap_size(ref ma_hpf2_config pConfig, out size_t pHeapSizeInBytes);
         
+        /// <summary>
+        /// Initializes a second-order high-pass filter with a pre-allocated heap buffer.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_hpf2_init_preallocated(ref ma_hpf2_config pConfig, IntPtr pHeap, ma_hpf2_ptr pHPF);
         
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe ma_result ma_hpf2_init(ref ma_hpf2_config pConfig, ma_allocation_callbacks* pAllocationCallbacks, ma_hpf2_ptr pHPF);
 
+        /// <summary>
+        /// Initializes a second-order high-pass filter with custom allocation callbacks.
+        /// </summary>
         public static ma_result ma_hpf2_init(ref ma_hpf2_config pConfig, ref ma_allocation_callbacks pAllocationCallbacks, ma_hpf2_ptr pHPF)
         {
             unsafe
@@ -1958,6 +3729,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Initializes a second-order high-pass filter with default allocation callbacks.
+        /// </summary>
         public static ma_result ma_hpf2_init(ref ma_hpf2_config pConfig, ma_hpf2_ptr pHPF)
         {
             unsafe
@@ -1969,6 +3743,9 @@ namespace MiniAudioEx.Native
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe void ma_hpf2_uninit(ma_hpf2_ptr pHPF, ma_allocation_callbacks* pAllocationCallbacks);
 
+        /// <summary>
+        /// Uninitializes a second-order high-pass filter with custom allocation callbacks.
+        /// </summary>
         public static void ma_hpf2_uninit(ma_hpf2_ptr pHPF, ref ma_allocation_callbacks pAllocationCallbacks)
         {
             unsafe
@@ -1980,6 +3757,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Uninitializes a second-order high-pass filter with default allocation callbacks.
+        /// </summary>
         public static void ma_hpf2_uninit(ma_hpf2_ptr pHPF)
         {
             unsafe
@@ -1988,27 +3768,48 @@ namespace MiniAudioEx.Native
             }
         }
         
+        /// <summary>
+        /// Reinitializes a second-order high-pass filter with a new config.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_hpf2_reinit(ref ma_hpf2_config pConfig, ma_hpf2_ptr pHPF);
         
+        /// <summary>
+        /// Processes PCM frames through the second-order high-pass filter.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_hpf2_process_pcm_frames(ma_hpf2_ptr pHPF, IntPtr pFramesOut, IntPtr pFramesIn, UInt64 frameCount);
         
+        /// <summary>
+        /// Gets the latency of the second-order high-pass filter in frames.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern UInt32 ma_hpf2_get_latency(ma_hpf2_ptr pHPF);
         
+        /// <summary>
+        /// Initializes a configurable-order high-pass filter config.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_hpf_config ma_hpf_config_init(ma_format format, UInt32 channels, UInt32 sampleRate, double cutoffFrequency, UInt32 order);
         
+        /// <summary>
+        /// Calculates the heap size required for a configurable-order high-pass filter.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_hpf_get_heap_size(ref ma_hpf_config pConfig, out size_t pHeapSizeInBytes);
         
+        /// <summary>
+        /// Initializes a configurable-order high-pass filter with a pre-allocated heap buffer.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_hpf_init_preallocated(ref ma_hpf_config pConfig, IntPtr pHeap, ma_hpf_ptr pLPF);
         
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe ma_result ma_hpf_init(ref ma_hpf_config pConfig, ma_allocation_callbacks* pAllocationCallbacks, ma_hpf_ptr pHPF);
 
+        /// <summary>
+        /// Initializes a configurable-order high-pass filter with custom allocation callbacks.
+        /// </summary>
         public static ma_result ma_hpf_init(ref ma_hpf_config pConfig, ref ma_allocation_callbacks pAllocationCallbacks, ma_hpf_ptr pHPF)
         {
             unsafe
@@ -2020,6 +3821,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Initializes a configurable-order high-pass filter with default allocation callbacks.
+        /// </summary>
         public static ma_result ma_hpf_init(ref ma_hpf_config pConfig, ma_hpf_ptr pHPF)
         {
             unsafe
@@ -2031,6 +3835,9 @@ namespace MiniAudioEx.Native
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe void ma_hpf_uninit(ma_hpf_ptr pHPF, ma_allocation_callbacks* pAllocationCallbacks);
 
+        /// <summary>
+        /// Uninitializes a configurable-order high-pass filter with custom allocation callbacks.
+        /// </summary>
         public static void ma_hpf_uninit(ma_hpf_ptr pHPF, ref ma_allocation_callbacks pAllocationCallbacks)
         {
             unsafe
@@ -2042,6 +3849,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Uninitializes a configurable-order high-pass filter with default allocation callbacks.
+        /// </summary>
         public static void ma_hpf_uninit(ma_hpf_ptr pHPF)
         {
             unsafe
@@ -2050,27 +3860,48 @@ namespace MiniAudioEx.Native
             }
         }
         
+        /// <summary>
+        /// Reinitializes a configurable-order high-pass filter with a new config.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_hpf_reinit(ref ma_hpf_config pConfig, ma_hpf_ptr pHPF);
         
+        /// <summary>
+        /// Processes PCM frames through the configurable-order high-pass filter.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_hpf_process_pcm_frames(ma_hpf_ptr pHPF, IntPtr pFramesOut, IntPtr pFramesIn, UInt64 frameCount);
         
+        /// <summary>
+        /// Gets the latency of the configurable-order high-pass filter in frames.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern UInt32 ma_hpf_get_latency(ma_hpf_ptr pHPF);
         
+        /// <summary>
+        /// Initializes a second-order band-pass filter config.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_bpf2_config ma_bpf2_config_init(ma_format format, UInt32 channels, UInt32 sampleRate, double cutoffFrequency, double q);
         
+        /// <summary>
+        /// Calculates the heap size required for a second-order band-pass filter.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_bpf2_get_heap_size(ref ma_bpf2_config pConfig, out size_t pHeapSizeInBytes);
         
+        /// <summary>
+        /// Initializes a second-order band-pass filter with a pre-allocated heap buffer.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_bpf2_init_preallocated(ref ma_bpf2_config pConfig, IntPtr pHeap, ma_bpf2_ptr pBPF);
         
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe ma_result ma_bpf2_init(ref ma_bpf2_config pConfig, ma_allocation_callbacks* pAllocationCallbacks, ma_bpf2_ptr pBPF);
 
+        /// <summary>
+        /// Initializes a second-order band-pass filter with custom allocation callbacks.
+        /// </summary>
         public static ma_result ma_bpf2_init(ref ma_bpf2_config pConfig, ref ma_allocation_callbacks pAllocationCallbacks, ma_bpf2_ptr pBPF)
         {
             unsafe
@@ -2082,6 +3913,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Initializes a second-order band-pass filter with default allocation callbacks.
+        /// </summary>
         public static ma_result ma_bpf2_init(ref ma_bpf2_config pConfig, ma_bpf2_ptr pBPF)
         {
             unsafe
@@ -2093,6 +3927,9 @@ namespace MiniAudioEx.Native
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe void ma_bpf2_uninit(ma_bpf2_ptr pBPF, ma_allocation_callbacks* pAllocationCallbacks);
 
+        /// <summary>
+        /// Uninitializes a second-order band-pass filter with custom allocation callbacks.
+        /// </summary>
         public static void ma_bpf2_uninit(ma_bpf2_ptr pBPF, ref ma_allocation_callbacks pAllocationCallbacks)
         {
             unsafe
@@ -2104,6 +3941,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Uninitializes a second-order band-pass filter with default allocation callbacks.
+        /// </summary>
         public static void ma_bpf2_uninit(ma_bpf2_ptr pBPF)
         {
             unsafe
@@ -2112,27 +3952,48 @@ namespace MiniAudioEx.Native
             }
         }
         
+        /// <summary>
+        /// Reinitializes a second-order band-pass filter with a new config.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_bpf2_reinit(ref ma_bpf2_config pConfig, ma_bpf2_ptr pBPF);
         
+        /// <summary>
+        /// Processes PCM frames through the second-order band-pass filter.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_bpf2_process_pcm_frames(ma_bpf2_ptr pBPF, IntPtr pFramesOut, IntPtr pFramesIn, UInt64 frameCount);
         
+        /// <summary>
+        /// Gets the latency of the second-order band-pass filter in frames.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern UInt32 ma_bpf2_get_latency(ma_bpf2_ptr pBPF);
         
+        /// <summary>
+        /// Initializes a configurable-order band-pass filter config.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_bpf_config ma_bpf_config_init(ma_format format, UInt32 channels, UInt32 sampleRate, double cutoffFrequency, UInt32 order);
         
+        /// <summary>
+        /// Calculates the heap size required for a configurable-order band-pass filter.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_bpf_get_heap_size(ref ma_bpf_config pConfig, out size_t pHeapSizeInBytes);
         
+        /// <summary>
+        /// Initializes a configurable-order band-pass filter with a pre-allocated heap buffer.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_bpf_init_preallocated(ref ma_bpf_config pConfig, IntPtr pHeap, ma_bpf_ptr pBPF);
         
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe ma_result ma_bpf_init(ref ma_bpf_config pConfig, ma_allocation_callbacks* pAllocationCallbacks, ma_bpf_ptr pBPF);
 
+        /// <summary>
+        /// Initializes a configurable-order band-pass filter with custom allocation callbacks.
+        /// </summary>
         public static ma_result ma_bpf_init(ref ma_bpf_config pConfig, ref ma_allocation_callbacks pAllocationCallbacks, ma_bpf_ptr pBPF)
         {
             unsafe
@@ -2144,6 +4005,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Initializes a configurable-order band-pass filter with default allocation callbacks.
+        /// </summary>
         public static ma_result ma_bpf_init(ref ma_bpf_config pConfig, ma_bpf_ptr pBPF)
         {
             unsafe
@@ -2155,6 +4019,9 @@ namespace MiniAudioEx.Native
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe void ma_bpf_uninit(ma_bpf_ptr pBPF, ma_allocation_callbacks* pAllocationCallbacks);
 
+        /// <summary>
+        /// Uninitializes a configurable-order band-pass filter with custom allocation callbacks.
+        /// </summary>
         public static void ma_bpf_uninit(ma_bpf_ptr pBPF, ref ma_allocation_callbacks pAllocationCallbacks)
         {
             unsafe
@@ -2166,6 +4033,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Uninitializes a configurable-order band-pass filter with default allocation callbacks.
+        /// </summary>
         public static void ma_bpf_uninit(ma_bpf_ptr pBPF)
         {
             unsafe
@@ -2174,27 +4044,48 @@ namespace MiniAudioEx.Native
             }
         }
         
+        /// <summary>
+        /// Reinitializes a configurable-order band-pass filter with a new config.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_bpf_reinit(ref ma_bpf_config pConfig, ma_bpf_ptr pBPF);
         
+        /// <summary>
+        /// Processes PCM frames through the configurable-order band-pass filter.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_bpf_process_pcm_frames(ma_bpf_ptr pBPF, IntPtr pFramesOut, IntPtr pFramesIn, UInt64 frameCount);
         
+        /// <summary>
+        /// Gets the latency of the configurable-order band-pass filter in frames.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern UInt32 ma_bpf_get_latency(ma_bpf_ptr pBPF);
         
+        /// <summary>
+        /// Initializes a second-order notch filter config.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_notch2_config ma_notch2_config_init(ma_format format, UInt32 channels, UInt32 sampleRate, double q, double frequency);
         
+        /// <summary>
+        /// Calculates the heap size required for a second-order notch filter.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_notch2_get_heap_size(ref ma_notch2_config pConfig, out size_t pHeapSizeInBytes);
         
+        /// <summary>
+        /// Initializes a second-order notch filter with a pre-allocated heap buffer.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_notch2_init_preallocated(ref ma_notch2_config pConfig, IntPtr pHeap, ma_notch2_ptr pFilter);
         
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe ma_result ma_notch2_init(ref ma_notch2_config pConfig, ma_allocation_callbacks* pAllocationCallbacks, ma_notch2_ptr pFilter);
 
+        /// <summary>
+        /// Initializes a second-order notch filter with custom allocation callbacks.
+        /// </summary>
         public static ma_result ma_notch2_init(ref ma_notch2_config pConfig, ref ma_allocation_callbacks pAllocationCallbacks, ma_notch2_ptr pFilter)
         {
             unsafe
@@ -2206,6 +4097,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Initializes a second-order notch filter with default allocation callbacks.
+        /// </summary>
         public static ma_result ma_notch2_init(ref ma_notch2_config pConfig, ma_notch2_ptr pFilter)
         {
             unsafe
@@ -2217,6 +4111,9 @@ namespace MiniAudioEx.Native
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe void ma_notch2_uninit(ma_notch2_ptr pFilter, ma_allocation_callbacks* pAllocationCallbacks);
 
+        /// <summary>
+        /// Uninitializes a second-order notch filter with custom allocation callbacks.
+        /// </summary>
         public static void ma_notch2_uninit(ma_notch2_ptr pFilter, ref ma_allocation_callbacks pAllocationCallbacks)
         {
             unsafe
@@ -2228,6 +4125,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Uninitializes a second-order notch filter with default allocation callbacks.
+        /// </summary>
         public static void ma_notch2_uninit(ma_notch2_ptr pFilter)
         {
             unsafe
@@ -2236,27 +4136,48 @@ namespace MiniAudioEx.Native
             }
         }
         
+        /// <summary>
+        /// Reinitializes a second-order notch filter with a new config.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_notch2_reinit(ref ma_notch2_config pConfig, ma_notch2_ptr pFilter);
         
+        /// <summary>
+        /// Processes PCM frames through the second-order notch filter.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_notch2_process_pcm_frames(ma_notch2_ptr pFilter, IntPtr pFramesOut, IntPtr pFramesIn, UInt64 frameCount);
         
+        /// <summary>
+        /// Gets the latency of the second-order notch filter in frames.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern UInt32 ma_notch2_get_latency(ma_notch2_ptr pFilter);
         
+        /// <summary>
+        /// Initializes a second-order peaking EQ filter config.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_peak2_config ma_peak2_config_init(ma_format format, UInt32 channels, UInt32 sampleRate, double gainDB, double q, double frequency);
         
+        /// <summary>
+        /// Calculates the heap size required for a second-order peaking EQ filter.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_peak2_get_heap_size(ref ma_peak2_config pConfig, out size_t pHeapSizeInBytes);
         
+        /// <summary>
+        /// Initializes a second-order peaking EQ filter with a pre-allocated heap buffer.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_peak2_init_preallocated(ref ma_peak2_config pConfig, IntPtr pHeap, ma_peak2_ptr pFilter);
         
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe ma_result ma_peak2_init(ref ma_peak2_config pConfig, ma_allocation_callbacks* pAllocationCallbacks, ma_peak2_ptr pFilter);
 
+        /// <summary>
+        /// Initializes a second-order peaking EQ filter with custom allocation callbacks.
+        /// </summary>
         public static ma_result ma_peak2_init(ref ma_peak2_config pConfig, ref ma_allocation_callbacks pAllocationCallbacks, ma_peak2_ptr pFilter)
         {
             unsafe
@@ -2268,6 +4189,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Initializes a second-order peaking EQ filter with default allocation callbacks.
+        /// </summary>
         public static ma_result ma_peak2_init(ref ma_peak2_config pConfig, ma_peak2_ptr pFilter)
         {
             unsafe
@@ -2279,6 +4203,9 @@ namespace MiniAudioEx.Native
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe void ma_peak2_uninit(ma_peak2_ptr pFilter, ma_allocation_callbacks* pAllocationCallbacks);
 
+        /// <summary>
+        /// Uninitializes a second-order peaking EQ filter with custom allocation callbacks.
+        /// </summary>
         public static void ma_peak2_uninit(ma_peak2_ptr pFilter, ref ma_allocation_callbacks pAllocationCallbacks)
         {
             unsafe
@@ -2290,27 +4217,48 @@ namespace MiniAudioEx.Native
             }
         }
         
+        /// <summary>
+        /// Reinitializes a second-order peaking EQ filter with a new config.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_peak2_reinit(ref ma_peak2_config pConfig, ma_peak2_ptr pFilter);
         
+        /// <summary>
+        /// Processes PCM frames through the second-order peaking EQ filter.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_peak2_process_pcm_frames(ma_peak2_ptr pFilter, IntPtr pFramesOut, IntPtr pFramesIn, UInt64 frameCount);
         
+        /// <summary>
+        /// Gets the latency of the second-order peaking EQ filter in frames.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern UInt32 ma_peak2_get_latency(ma_peak2_ptr pFilter);
         
+        /// <summary>
+        /// Initializes a second-order low-shelf filter config.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_loshelf2_config ma_loshelf2_config_init(ma_format format, UInt32 channels, UInt32 sampleRate, double gainDB, double shelfSlope, double frequency);
         
+        /// <summary>
+        /// Calculates the heap size required for a second-order low-shelf filter.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_loshelf2_get_heap_size(ref ma_loshelf2_config pConfig, out size_t pHeapSizeInBytes);
         
+        /// <summary>
+        /// Initializes a second-order low-shelf filter with a pre-allocated heap buffer.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_loshelf2_init_preallocated(ref ma_loshelf2_config pConfig, IntPtr pHeap, ma_loshelf2_ptr pFilter);
         
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe ma_result ma_loshelf2_init(ref ma_loshelf2_config pConfig, ma_allocation_callbacks* pAllocationCallbacks, ma_loshelf2_ptr pFilter);
 
+        /// <summary>
+        /// Initializes a second-order low-shelf filter with custom allocation callbacks.
+        /// </summary>
         public static ma_result ma_loshelf2_init(ref ma_loshelf2_config pConfig, ref ma_allocation_callbacks pAllocationCallbacks, ma_loshelf2_ptr pFilter)
         {
             unsafe
@@ -2322,6 +4270,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Initializes a second-order low-shelf filter with default allocation callbacks.
+        /// </summary>
         public static ma_result ma_loshelf2_init(ref ma_loshelf2_config pConfig, ma_loshelf2_ptr pFilter)
         {
             unsafe
@@ -2333,6 +4284,9 @@ namespace MiniAudioEx.Native
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe void ma_loshelf2_uninit(ma_loshelf2_ptr pFilter, ma_allocation_callbacks* pAllocationCallbacks);
 
+        /// <summary>
+        /// Uninitializes a second-order low-shelf filter with custom allocation callbacks.
+        /// </summary>
         public static void ma_loshelf2_uninit(ma_loshelf2_ptr pFilter, ref ma_allocation_callbacks pAllocationCallbacks)
         {
             unsafe
@@ -2344,6 +4298,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Uninitializes a second-order low-shelf filter with default allocation callbacks.
+        /// </summary>
         public static void ma_loshelf2_uninit(ma_loshelf2_ptr pFilter)
         {
             unsafe
@@ -2352,27 +4309,48 @@ namespace MiniAudioEx.Native
             }
         }
         
+        /// <summary>
+        /// Reinitializes a second-order low-shelf filter with a new config.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_loshelf2_reinit(ref ma_loshelf2_config pConfig, ma_loshelf2_ptr pFilter);
         
+        /// <summary>
+        /// Processes PCM frames through the second-order low-shelf filter.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_loshelf2_process_pcm_frames(ma_loshelf2_ptr pFilter, IntPtr pFramesOut, IntPtr pFramesIn, UInt64 frameCount);
         
+        /// <summary>
+        /// Gets the latency of the second-order low-shelf filter in frames.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern UInt32 ma_loshelf2_get_latency(ma_loshelf2_ptr pFilter);
         
+        /// <summary>
+        /// Initializes a second-order high-shelf filter config.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_hishelf2_config ma_hishelf2_config_init(ma_format format, UInt32 channels, UInt32 sampleRate, double gainDB, double shelfSlope, double frequency);
         
+        /// <summary>
+        /// Calculates the heap size required for a second-order high-shelf filter.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_hishelf2_get_heap_size(ref ma_hishelf2_config pConfig, out size_t pHeapSizeInBytes);
         
+        /// <summary>
+        /// Initializes a second-order high-shelf filter with a pre-allocated heap buffer.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_hishelf2_init_preallocated(ref ma_hishelf2_config pConfig, IntPtr pHeap, ma_hishelf2_ptr pFilter);
         
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe ma_result ma_hishelf2_init(ref ma_hishelf2_config pConfig, ma_allocation_callbacks* pAllocationCallbacks, ma_hishelf2_ptr pFilter);
 
+        /// <summary>
+        /// Initializes a second-order high-shelf filter with custom allocation callbacks.
+        /// </summary>
         public static ma_result ma_hishelf2_init(ref ma_hishelf2_config pConfig, ref ma_allocation_callbacks pAllocationCallbacks, ma_hishelf2_ptr pFilter)
         {
             unsafe
@@ -2384,6 +4362,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Initializes a second-order high-shelf filter with default allocation callbacks.
+        /// </summary>
         public static ma_result ma_hishelf2_init(ref ma_hishelf2_config pConfig, ma_hishelf2_ptr pFilter)
         {
             unsafe
@@ -2395,6 +4376,9 @@ namespace MiniAudioEx.Native
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe void ma_hishelf2_uninit(ma_hishelf2_ptr pFilter, ma_allocation_callbacks* pAllocationCallbacks);
 
+        /// <summary>
+        /// Uninitializes a second-order high-shelf filter with custom allocation callbacks.
+        /// </summary>
         public static void ma_hishelf2_uninit(ma_hishelf2_ptr pFilter, ref ma_allocation_callbacks pAllocationCallbacks)
         {
             unsafe
@@ -2406,6 +4390,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Uninitializes a second-order high-shelf filter with default allocation callbacks.
+        /// </summary>
         public static void ma_hishelf2_uninit(ma_hishelf2_ptr pFilter)
         {
             unsafe
@@ -2414,21 +4401,36 @@ namespace MiniAudioEx.Native
             }
         }
         
+        /// <summary>
+        /// Reinitializes a second-order high-shelf filter with a new config.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_hishelf2_reinit(ref ma_hishelf2_config pConfig, ma_hishelf2_ptr pFilter);
         
+        /// <summary>
+        /// Processes PCM frames through the second-order high-shelf filter.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_hishelf2_process_pcm_frames(ma_hishelf2_ptr pFilter, IntPtr pFramesOut, IntPtr pFramesIn, UInt64 frameCount);
         
+        /// <summary>
+        /// Gets the latency of the second-order high-shelf filter in frames.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern UInt32 ma_hishelf2_get_latency(ma_hishelf2_ptr pFilter);
 
+        /// <summary>
+        /// Initializes a low-pass filter node config with the specified channels, sample rate, cutoff frequency, and filter order.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_lpf_node_config ma_lpf_node_config_init(ma_uint32 channels, ma_uint32 sampleRate, double cutoffFrequency, ma_uint32 order);
 
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe ma_result ma_lpf_node_init(ma_node_graph_ptr pNodeGraph, ref ma_lpf_node_config pConfig, ma_allocation_callbacks* pAllocationCallbacks, ma_lpf_node_ptr pNode);
 
+        /// <summary>
+        /// Initializes a low-pass filter node within a node graph with custom allocation callbacks.
+        /// </summary>
         public static ma_result ma_lpf_node_init(ma_node_graph_ptr pNodeGraph, ref ma_lpf_node_config pConfig, ref ma_allocation_callbacks pAllocationCallbacks, ma_lpf_node_ptr pNode)
         {
             unsafe
@@ -2440,6 +4442,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Initializes a low-pass filter node within a node graph with default allocation callbacks.
+        /// </summary>
         public static ma_result ma_lpf_node_init(ma_node_graph_ptr pNodeGraph, ref ma_lpf_node_config pConfig, ma_lpf_node_ptr pNode)
         {
             unsafe
@@ -2448,12 +4453,18 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Reinitializes a low-pass filter node with a new filter configuration.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_lpf_node_reinit(ref ma_lpf_config pConfig, ma_lpf_node_ptr pNode);
 
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe void ma_lpf_node_uninit(ma_lpf_node_ptr pNode, ma_allocation_callbacks* pAllocationCallbacks);
 
+        /// <summary>
+        /// Uninitializes a low-pass filter node with custom allocation callbacks.
+        /// </summary>
         public static void ma_lpf_node_uninit(ma_lpf_node_ptr pNode, ref ma_allocation_callbacks pAllocationCallbacks)
         {
             unsafe
@@ -2465,6 +4476,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Uninitializes a low-pass filter node with default allocation callbacks.
+        /// </summary>
         public static void ma_lpf_node_uninit(ma_lpf_node_ptr pNode)
         {
             unsafe
@@ -2473,12 +4487,18 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Initializes a high-pass filter node config with the specified channels, sample rate, cutoff frequency, and filter order.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_hpf_node_config ma_hpf_node_config_init(ma_uint32 channels, ma_uint32 sampleRate, double cutoffFrequency, ma_uint32 order);
 
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe ma_result ma_hpf_node_init(ma_node_graph_ptr pNodeGraph, ref ma_hpf_node_config pConfig, ma_allocation_callbacks* pAllocationCallbacks, ma_hpf_node_ptr pNode);
 
+        /// <summary>
+        /// Initializes a high-pass filter node within a node graph with custom allocation callbacks.
+        /// </summary>
         public static ma_result ma_hpf_node_init(ma_node_graph_ptr pNodeGraph, ref ma_hpf_node_config pConfig, ref ma_allocation_callbacks pAllocationCallbacks, ma_hpf_node_ptr pNode)
         {
             unsafe
@@ -2490,6 +4510,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Initializes a high-pass filter node within a node graph with default allocation callbacks.
+        /// </summary>
         public static ma_result ma_hpf_node_init(ma_node_graph_ptr pNodeGraph, ref ma_hpf_node_config pConfig, ma_hpf_node_ptr pNode)
         {
             unsafe
@@ -2498,12 +4521,18 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Reinitializes a high-pass filter node with a new filter configuration.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_hpf_node_reinit(ref ma_hpf_config pConfig, ma_hpf_node_ptr pNode);
 
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe void ma_hpf_node_uninit(ma_hpf_node_ptr pNode, ma_allocation_callbacks* pAllocationCallbacks);
 
+        /// <summary>
+        /// Uninitializes a high-pass filter node with custom allocation callbacks.
+        /// </summary>
         public static void ma_hpf_node_uninit(ma_hpf_node_ptr pNode, ref ma_allocation_callbacks pAllocationCallbacks)
         {
             unsafe
@@ -2515,6 +4544,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Uninitializes a high-pass filter node with default allocation callbacks.
+        /// </summary>
         public static void ma_hpf_node_uninit(ma_hpf_node_ptr pNode)
         {
             unsafe
@@ -2523,12 +4555,18 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Initializes a band-pass filter node config with the specified channels, sample rate, cutoff frequency, and filter order.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_bpf_node_config ma_bpf_node_config_init(ma_uint32 channels, ma_uint32 sampleRate, double cutoffFrequency, ma_uint32 order);
 
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe ma_result ma_bpf_node_init(ma_node_graph_ptr pNodeGraph, ref ma_bpf_node_config pConfig, ma_allocation_callbacks* pAllocationCallbacks, ma_bpf_node_ptr pNode);
 
+        /// <summary>
+        /// Initializes a band-pass filter node within a node graph with custom allocation callbacks.
+        /// </summary>
         public static ma_result ma_bpf_node_init(ma_node_graph_ptr pNodeGraph, ref ma_bpf_node_config pConfig, ref ma_allocation_callbacks pAllocationCallbacks, ma_bpf_node_ptr pNode)
         {
             unsafe
@@ -2540,6 +4578,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Initializes a band-pass filter node within a node graph with default allocation callbacks.
+        /// </summary>
         public static ma_result ma_bpf_node_init(ma_node_graph_ptr pNodeGraph, ref ma_bpf_node_config pConfig, ma_bpf_node_ptr pNode)
         {
             unsafe
@@ -2548,12 +4589,18 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Reinitializes a band-pass filter node with a new filter configuration.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_bpf_node_reinit(ref ma_bpf_config pConfig, ma_bpf_node_ptr pNode);
 
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe void ma_bpf_node_uninit(ma_bpf_node_ptr pNode, ma_allocation_callbacks* pAllocationCallbacks);
 
+        /// <summary>
+        /// Uninitializes a band-pass filter node with custom allocation callbacks.
+        /// </summary>
         public static void ma_bpf_node_uninit(ma_bpf_node_ptr pNode, ref ma_allocation_callbacks pAllocationCallbacks)
         {
             unsafe
@@ -2565,6 +4612,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Uninitializes a band-pass filter node with default allocation callbacks.
+        /// </summary>
         public static void ma_bpf_node_uninit(ma_bpf_node_ptr pNode)
         {
             unsafe
@@ -2573,12 +4623,18 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Initializes a notch (band-reject) filter node config with the specified channels, sample rate, Q factor, and frequency.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_notch_node_config ma_notch_node_config_init(ma_uint32 channels, ma_uint32 sampleRate, double q, double frequency);
 
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe ma_result ma_notch_node_init(ma_node_graph_ptr pNodeGraph, ref ma_notch_node_config pConfig, ma_allocation_callbacks* pAllocationCallbacks, ma_notch_node_ptr pNode);
 
+        /// <summary>
+        /// Initializes a notch filter node within a node graph with custom allocation callbacks.
+        /// </summary>
         public static ma_result ma_notch_node_init(ma_node_graph_ptr pNodeGraph, ref ma_notch_node_config pConfig, ref ma_allocation_callbacks pAllocationCallbacks, ma_notch_node_ptr pNode)
         {
             unsafe
@@ -2590,6 +4646,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Initializes a notch filter node within a node graph with default allocation callbacks.
+        /// </summary>
         public static ma_result ma_notch_node_init(ma_node_graph_ptr pNodeGraph, ref ma_notch_node_config pConfig, ma_notch_node_ptr pNode)
         {
             unsafe
@@ -2598,12 +4657,18 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Reinitializes a notch filter node with a new filter configuration.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_notch_node_reinit(ref ma_notch_config pConfig, ma_notch_node_ptr pNode);
 
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe void ma_notch_node_uninit(ma_notch_node_ptr pNode, ma_allocation_callbacks* pAllocationCallbacks);
 
+        /// <summary>
+        /// Uninitializes a notch filter node with custom allocation callbacks.
+        /// </summary>
         public static void ma_notch_node_uninit(ma_notch_node_ptr pNode, ref ma_allocation_callbacks pAllocationCallbacks)
         {
             unsafe
@@ -2615,6 +4680,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Uninitializes a notch filter node with default allocation callbacks.
+        /// </summary>
         public static void ma_notch_node_uninit(ma_notch_node_ptr pNode)
         {
             unsafe
@@ -2623,12 +4691,18 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Initializes a peaking EQ filter node config with the specified channels, sample rate, gain in dB, Q factor, and frequency.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_peak_node_config ma_peak_node_config_init(ma_uint32 channels, ma_uint32 sampleRate, double gainDB, double q, double frequency);
 
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe ma_result ma_peak_node_init(ma_node_graph_ptr pNodeGraph, ref ma_peak_node_config pConfig, ma_allocation_callbacks* pAllocationCallbacks, ma_peak_node_ptr pNode);
 
+        /// <summary>
+        /// Initializes a peaking EQ filter node within a node graph with custom allocation callbacks.
+        /// </summary>
         public static ma_result ma_peak_node_init(ma_node_graph_ptr pNodeGraph, ref ma_peak_node_config pConfig, ref ma_allocation_callbacks pAllocationCallbacks, ma_peak_node_ptr pNode)
         {
             unsafe
@@ -2640,6 +4714,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Initializes a peaking EQ filter node within a node graph with default allocation callbacks.
+        /// </summary>
         public static ma_result ma_peak_node_init(ma_node_graph_ptr pNodeGraph, ref ma_peak_node_config pConfig, ma_peak_node_ptr pNode)
         {
             unsafe
@@ -2648,12 +4725,18 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Reinitializes a peaking EQ filter node with a new filter configuration.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_peak_node_reinit(ref ma_peak_config pConfig, ma_peak_node_ptr pNode);
 
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe void ma_peak_node_uninit(ma_peak_node_ptr pNode, ma_allocation_callbacks* pAllocationCallbacks);
 
+        /// <summary>
+        /// Uninitializes a peaking EQ filter node with custom allocation callbacks.
+        /// </summary>
         public static void ma_peak_node_uninit(ma_peak_node_ptr pNode, ref ma_allocation_callbacks pAllocationCallbacks)
         {
             unsafe
@@ -2665,6 +4748,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Uninitializes a peaking EQ filter node with default allocation callbacks.
+        /// </summary>
         public static void ma_peak_node_uninit(ma_peak_node_ptr pNode)
         {
             unsafe
@@ -2673,12 +4759,18 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Initializes a low-shelf filter node config with the specified channels, sample rate, gain in dB, Q factor, and frequency.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_loshelf_node_config ma_loshelf_node_config_init(ma_uint32 channels, ma_uint32 sampleRate, double gainDB, double q, double frequency);
 
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe ma_result ma_loshelf_node_init(ma_node_graph_ptr pNodeGraph, ref ma_loshelf_node_config pConfig, ma_allocation_callbacks* pAllocationCallbacks, ma_loshelf_node_ptr pNode);
 
+        /// <summary>
+        /// Initializes a low-shelf filter node within a node graph with custom allocation callbacks.
+        /// </summary>
         public static ma_result ma_loshelf_node_init(ma_node_graph_ptr pNodeGraph, ref ma_loshelf_node_config pConfig, ref ma_allocation_callbacks pAllocationCallbacks, ma_loshelf_node_ptr pNode)
         {
             unsafe
@@ -2690,6 +4782,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Initializes a low-shelf filter node within a node graph with default allocation callbacks.
+        /// </summary>
         public static ma_result ma_loshelf_node_init(ma_node_graph_ptr pNodeGraph, ref ma_loshelf_node_config pConfig, ma_loshelf_node_ptr pNode)
         {
             unsafe
@@ -2698,12 +4793,18 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Reinitializes a low-shelf filter node with a new filter configuration.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_loshelf_node_reinit(ref ma_loshelf_config pConfig, ma_loshelf_node_ptr pNode);
 
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe void ma_loshelf_node_uninit(ma_loshelf_node_ptr pNode, ma_allocation_callbacks* pAllocationCallbacks);
 
+        /// <summary>
+        /// Uninitializes a low-shelf filter node with custom allocation callbacks.
+        /// </summary>
         public static void ma_loshelf_node_uninit(ma_loshelf_node_ptr pNode, ref ma_allocation_callbacks pAllocationCallbacks)
         {
             unsafe
@@ -2715,6 +4816,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Uninitializes a low-shelf filter node with default allocation callbacks.
+        /// </summary>
         public static void ma_loshelf_node_uninit(ma_loshelf_node_ptr pNode)
         {
             unsafe
@@ -2723,12 +4827,18 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Initializes a high-shelf filter node config with the specified channels, sample rate, gain in dB, Q factor, and frequency.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_hishelf_node_config ma_hishelf_node_config_init(ma_uint32 channels, ma_uint32 sampleRate, double gainDB, double q, double frequency);
 
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe ma_result ma_hishelf_node_init(ma_node_graph_ptr pNodeGraph, ref ma_hishelf_node_config pConfig, ma_allocation_callbacks* pAllocationCallbacks, ma_hishelf_node_ptr pNode);
 
+        /// <summary>
+        /// Initializes a high-shelf filter node within a node graph with custom allocation callbacks.
+        /// </summary>
         public static ma_result ma_hishelf_node_init(ma_node_graph_ptr pNodeGraph, ref ma_hishelf_node_config pConfig, ref ma_allocation_callbacks pAllocationCallbacks, ma_hishelf_node_ptr pNode)
         {
             unsafe
@@ -2740,6 +4850,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Initializes a high-shelf filter node within a node graph with default allocation callbacks.
+        /// </summary>
         public static ma_result ma_hishelf_node_init(ma_node_graph_ptr pNodeGraph, ref ma_hishelf_node_config pConfig, ma_hishelf_node_ptr pNode)
         {
             unsafe
@@ -2748,12 +4861,18 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Reinitializes a high-shelf filter node with a new filter configuration.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_hishelf_node_reinit(ref ma_hishelf_config pConfig, ma_hishelf_node_ptr pNode);
 
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe void ma_hishelf_node_uninit(ma_hishelf_node_ptr pNode, ma_allocation_callbacks* pAllocationCallbacks);
 
+        /// <summary>
+        /// Uninitializes a high-shelf filter node with custom allocation callbacks.
+        /// </summary>
         public static void ma_hishelf_node_uninit(ma_hishelf_node_ptr pNode, ref ma_allocation_callbacks pAllocationCallbacks)
         {
             unsafe
@@ -2765,6 +4884,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Uninitializes a high-shelf filter node with default allocation callbacks.
+        /// </summary>
         public static void ma_hishelf_node_uninit(ma_hishelf_node_ptr pNode)
         {
             unsafe
@@ -2774,12 +4896,18 @@ namespace MiniAudioEx.Native
         }
 
         //ma_delay
+        /// <summary>
+        /// Initializes a delay config with the specified channels, sample rate, delay in frames, and decay factor.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_delay_config ma_delay_config_init(ma_uint32 channels, ma_uint32 sampleRate, ma_uint32 delayInFrames, float decay);
 
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe ma_result ma_delay_init(ref ma_delay_config pConfig, ma_allocation_callbacks* pAllocationCallbacks, ma_delay_ptr pDelay);
 
+        /// <summary>
+        /// Initializes a delay effect with custom allocation callbacks.
+        /// </summary>
         public static ma_result ma_delay_init(ref ma_delay_config pConfig, ref ma_allocation_callbacks pAllocationCallbacks, ma_delay_ptr pDelay)
         {
             unsafe
@@ -2791,6 +4919,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Initializes a delay effect with default allocation callbacks.
+        /// </summary>
         public static ma_result ma_delay_init(ref ma_delay_config pConfig, ma_delay_ptr pDelay)
         {
             unsafe
@@ -2802,6 +4933,9 @@ namespace MiniAudioEx.Native
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe void ma_delay_uninit(ma_delay_ptr pDelay, ma_allocation_callbacks* pAllocationCallbacks);
 
+        /// <summary>
+        /// Uninitializes a delay effect with custom allocation callbacks.
+        /// </summary>
         public static void ma_delay_uninit(ma_delay_ptr pDelay, ref ma_allocation_callbacks pAllocationCallbacks)
         {
             unsafe
@@ -2813,6 +4947,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Uninitializes a delay effect with default allocation callbacks.
+        /// </summary>
         public static void ma_delay_uninit(ma_delay_ptr pDelay)
         {
             unsafe
@@ -2821,34 +4958,61 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Processes PCM frames through the delay effect, producing delayed output.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_delay_process_pcm_frames(ma_delay_ptr pDelay, IntPtr pFramesOut, IntPtr pFramesIn, UInt32 frameCount);
 
+        /// <summary>
+        /// Sets the wet (processed) signal level of the delay.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_delay_set_wet(ma_delay_ptr pDelay, float value);
 
+        /// <summary>
+        /// Gets the wet (processed) signal level of the delay.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_delay_get_wet(ma_delay_ptr pDelay);
 
+        /// <summary>
+        /// Sets the dry (unprocessed) signal level of the delay.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_delay_set_dry(ma_delay_ptr pDelay, float value);
 
+        /// <summary>
+        /// Gets the dry (unprocessed) signal level of the delay.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_delay_get_dry(ma_delay_ptr pDelay);
 
+        /// <summary>
+        /// Sets the decay factor of the delay, controlling how much the delayed signal attenuates over time.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_delay_set_decay(ma_delay_ptr pDelay, float value);
 
+        /// <summary>
+        /// Gets the decay factor of the delay.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_delay_get_decay(ma_delay_ptr pDelay);
 
         //ma_delay_node
+        /// <summary>
+        /// Initializes a delay node config with the specified channels, sample rate, delay in frames, and decay factor.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_delay_node_config ma_delay_node_config_init(ma_uint32 channels, ma_uint32 sampleRate, ma_uint32 delayInFrames, float decay);
 
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe ma_result ma_delay_node_init(ma_node_graph_ptr pNodeGraph, ref ma_delay_node_config pConfig, ma_allocation_callbacks* pAllocationCallbacks, ma_delay_node_ptr pDelayNode);
 
+        /// <summary>
+        /// Initializes a delay node within a node graph with custom allocation callbacks.
+        /// </summary>
         public static ma_result ma_delay_node_init(ma_node_graph_ptr pNodeGraph, ref ma_delay_node_config pConfig, ref ma_allocation_callbacks pAllocationCallbacks, ma_delay_node_ptr pDelayNode)
         {
             unsafe
@@ -2860,6 +5024,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Initializes a delay node within a node graph with default allocation callbacks.
+        /// </summary>
         public static ma_result ma_delay_node_init(ma_node_graph_ptr pNodeGraph, ref ma_delay_node_config pConfig, ma_delay_node_ptr pDelayNode)
         {
             unsafe
@@ -2871,6 +5038,9 @@ namespace MiniAudioEx.Native
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe void ma_delay_node_uninit(ma_delay_node_ptr pDelayNode, ma_allocation_callbacks* pAllocationCallbacks);
 
+        /// <summary>
+        /// Uninitializes a delay node with custom allocation callbacks.
+        /// </summary>
         public static void ma_delay_node_uninit(ma_delay_node_ptr pDelayNode, ref ma_allocation_callbacks pAllocationCallbacks)
         {
             unsafe
@@ -2882,6 +5052,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Uninitializes a delay node with default allocation callbacks.
+        /// </summary>
         public static void ma_delay_node_uninit(ma_delay_node_ptr pDelayNode)
         {
             unsafe
@@ -2890,31 +5063,55 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Sets the wet (processed) signal level of the delay node.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_delay_node_set_wet(ma_delay_node_ptr pDelayNode, float value);
 
+        /// <summary>
+        /// Gets the wet (processed) signal level of the delay node.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_delay_node_get_wet(ma_delay_node_ptr pDelayNode);
 
+        /// <summary>
+        /// Sets the dry (unprocessed) signal level of the delay node.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_delay_node_set_dry(ma_delay_node_ptr pDelayNode, float value);
 
+        /// <summary>
+        /// Gets the dry (unprocessed) signal level of the delay node.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_delay_node_get_dry(ma_delay_node_ptr pDelayNode);
 
+        /// <summary>
+        /// Sets the decay factor of the delay node.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_delay_node_set_decay(ma_delay_node_ptr pDelayNode, float value);
 
+        /// <summary>
+        /// Gets the decay factor of the delay node.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern float ma_delay_node_get_decay(ma_delay_node_ptr pDelayNode);
 
         //ma_splitter_node
+        /// <summary>
+        /// Initializes a splitter node config with the specified number of channels. A splitter node duplicates its input to multiple output buses.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_splitter_node_config ma_splitter_node_config_init(ma_uint32 channels);
 
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe ma_result ma_splitter_node_init(ma_node_graph_ptr pNodeGraph, ref ma_splitter_node_config pConfig, ma_allocation_callbacks *pAllocationCallbacks, ma_splitter_node_ptr pSplitterNode);
 
+        /// <summary>
+        /// Initializes a splitter node within a node graph with custom allocation callbacks.
+        /// </summary>
         public static ma_result ma_splitter_node_init(ma_node_graph_ptr pNodeGraph, ref ma_splitter_node_config pConfig, ref ma_allocation_callbacks pAllocationCallbacks, ma_splitter_node_ptr pSplitterNode)
         {
             unsafe
@@ -2926,6 +5123,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Initializes a splitter node within a node graph with default allocation callbacks.
+        /// </summary>
         public static ma_result ma_splitter_node_init(ma_node_graph_ptr pNodeGraph, ref ma_splitter_node_config pConfig, ma_splitter_node_ptr pSplitterNode)
         {
             unsafe
@@ -2937,6 +5137,9 @@ namespace MiniAudioEx.Native
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe void ma_splitter_node_uninit(ma_splitter_node_ptr pSplitterNode, ma_allocation_callbacks* pAllocationCallbacks);
 
+        /// <summary>
+        /// Uninitializes a splitter node with custom allocation callbacks.
+        /// </summary>
         public static void ma_splitter_node_uninit(ma_splitter_node_ptr pSplitterNode, ref ma_allocation_callbacks pAllocationCallbacks)
         {
             unsafe
@@ -2948,6 +5151,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Uninitializes a splitter node with default allocation callbacks.
+        /// </summary>
         public static void ma_splitter_node_uninit(ma_splitter_node_ptr pSplitterNode)
         {
             unsafe
@@ -2957,72 +5163,138 @@ namespace MiniAudioEx.Native
         }
 
         //ma_waveform
+        /// <summary>
+        /// Initializes a waveform config with the specified format, channels, sample rate, waveform type, amplitude, and frequency.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_waveform_config ma_waveform_config_init(ma_format format, ma_uint32 channels, ma_uint32 sampleRate, ma_waveform_type type, double amplitude, double frequency);
 
+        /// <summary>
+        /// Initializes a waveform generator which produces periodic waveforms (sine, square, triangle, sawtooth).
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_waveform_init(ref ma_waveform_config pConfig, ma_waveform_ptr pWaveform);
 
+        /// <summary>
+        /// Uninitializes a waveform generator and releases its resources.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_waveform_uninit(ma_waveform_ptr pWaveform);
 
+        /// <summary>
+        /// Reads PCM frames from the waveform generator.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_waveform_read_pcm_frames(ma_waveform_ptr pWaveform, IntPtr pFramesOut, ma_uint64 frameCount, out ma_uint64 pFramesRead);
 
+        /// <summary>
+        /// Seeks the waveform generator to a specific PCM frame index.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_waveform_seek_to_pcm_frame(ma_waveform_ptr pWaveform, ma_uint64 frameIndex);
 
+        /// <summary>
+        /// Sets the amplitude of the generated waveform.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_waveform_set_amplitude(ma_waveform_ptr pWaveform, double amplitude);
 
+        /// <summary>
+        /// Sets the frequency of the generated waveform in Hz.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_waveform_set_frequency(ma_waveform_ptr pWaveform, double frequency);
 
+        /// <summary>
+        /// Sets the waveform type (sine, square, triangle, sawtooth).
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_waveform_set_type(ma_waveform_ptr pWaveform, ma_waveform_type type);
 
+        /// <summary>
+        /// Sets the sample rate of the waveform generator.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_waveform_set_sample_rate(ma_waveform_ptr pWaveform, ma_uint32 sampleRate);
 
+        /// <summary>
+        /// Initializes a pulse waveform config with the specified format, channels, sample rate, duty cycle, amplitude, and frequency.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_pulsewave_config ma_pulsewave_config_init(ma_format format, ma_uint32 channels, ma_uint32 sampleRate, double dutyCycle, double amplitude, double frequency);
 
+        /// <summary>
+        /// Initializes a pulse waveform generator which produces a rectangular wave with a controllable duty cycle.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_pulsewave_init(ref ma_pulsewave_config pConfig, ma_pulsewave_ptr pWaveform);
 
+        /// <summary>
+        /// Uninitializes a pulse waveform generator and releases its resources.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ma_pulsewave_uninit(ma_pulsewave_ptr pWaveform);
 
+        /// <summary>
+        /// Reads PCM frames from the pulse waveform generator.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_pulsewave_read_pcm_frames(ma_pulsewave_ptr pWaveform, IntPtr pFramesOut, ma_uint64 frameCount, out ma_uint64 pFramesRead);
 
+        /// <summary>
+        /// Seeks the pulse waveform generator to a specific PCM frame index.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_pulsewave_seek_to_pcm_frame(ma_pulsewave_ptr pWaveform, ma_uint64 frameIndex);
 
+        /// <summary>
+        /// Sets the amplitude of the pulse waveform.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_pulsewave_set_amplitude(ma_pulsewave_ptr pWaveform, double amplitude);
 
+        /// <summary>
+        /// Sets the frequency of the pulse waveform in Hz.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_pulsewave_set_frequency(ma_pulsewave_ptr pWaveform, double frequency);
 
+        /// <summary>
+        /// Sets the sample rate of the pulse waveform generator.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_pulsewave_set_sample_rate(ma_pulsewave_ptr pWaveform, ma_uint32 sampleRate);
 
+        /// <summary>
+        /// Sets the duty cycle of the pulse waveform (0.0 to 1.0, where 0.5 is a square wave).
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_pulsewave_set_duty_cycle(ma_pulsewave_ptr pWaveform, double dutyCycle);
 
+        /// <summary>
+        /// Initializes a noise generator config with the specified format, channels, noise type, seed, and amplitude.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_noise_config ma_noise_config_init(ma_format format, ma_uint32 channels, ma_noise_type type, ma_int32 seed, double amplitude);
 
+        /// <summary>
+        /// Gets the required heap size for a noise generator with the given config.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_noise_get_heap_size(ref ma_noise_config pConfig, out size_t pHeapSizeInBytes);
 
+        /// <summary>
+        /// Initializes a noise generator with a pre-allocated heap buffer.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_noise_init_preallocated(ref ma_noise_config pConfig, IntPtr pHeap, ma_noise_ptr pNoise);
 
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe ma_result ma_noise_init(ref ma_noise_config pConfig, ma_allocation_callbacks* pAllocationCallbacks, ma_noise_ptr pNoise);
 
+        /// <summary>
+        /// Initializes a noise generator with custom allocation callbacks. Produces white, pink, or Brownian noise.
+        /// </summary>
         public static ma_result ma_noise_init(ref ma_noise_config pConfig, ref ma_allocation_callbacks pAllocationCallbacks, ma_noise_ptr pNoise)
         {
             unsafe
@@ -3034,6 +5306,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Initializes a noise generator with default allocation callbacks.
+        /// </summary>
         public static ma_result ma_noise_init(ref ma_noise_config pConfig, ma_noise_ptr pNoise)
         {
             unsafe
@@ -3045,6 +5320,9 @@ namespace MiniAudioEx.Native
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         private static extern unsafe void ma_noise_uninit(ma_noise_ptr pNoise, ma_allocation_callbacks* pAllocationCallbacks);
 
+        /// <summary>
+        /// Uninitializes a noise generator with custom allocation callbacks.
+        /// </summary>
         public static void ma_noise_uninit(ma_noise_ptr pNoise, ref ma_allocation_callbacks pAllocationCallbacks)
         {
             unsafe
@@ -3055,7 +5333,10 @@ namespace MiniAudioEx.Native
                 }
             }
         }
-        
+
+        /// <summary>
+        /// Uninitializes a noise generator with default allocation callbacks.
+        /// </summary>
         public static void ma_noise_uninit(ma_noise_ptr pNoise)
         {
             unsafe
@@ -3064,15 +5345,27 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Reads PCM frames from the noise generator.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_noise_read_pcm_frames(ma_noise_ptr pNoise, IntPtr pFramesOut, ma_uint64 frameCount, out ma_uint64 pFramesRead);
 
+        /// <summary>
+        /// Sets the amplitude of the noise generator.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_noise_set_amplitude(ma_noise_ptr pNoise, double amplitude);
 
+        /// <summary>
+        /// Sets the seed for the noise generator's random number generator.
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_noise_set_seed(ma_noise_ptr pNoise, ma_int32 seed);
 
+        /// <summary>
+        /// Sets the noise type (white, pink, or Brownian).
+        /// </summary>
         [DllImport(LIB_MINIAUDIO_EX, CallingConvention = CallingConvention.Cdecl)]
         public static extern ma_result ma_noise_set_type(ma_noise_ptr pNoise, ma_noise_type type);
     }

--- a/src/Native/MiniAudioNativeDelegates.cs
+++ b/src/Native/MiniAudioNativeDelegates.cs
@@ -58,129 +58,506 @@ namespace MiniAudioEx.Native
     using ma_uint64 = UInt64;
 
     // ma_callbacks
+
+    /// <summary>
+    /// Callback for when a sound reaches the end. This is fired from the audio thread.
+    /// Do not restart, uninitialize or otherwise change the state of the sound from
+    /// this callback. Instead fire an event or set a variable to indicate to a
+    /// different thread to change the state of the sound. Will not be fired in
+    /// response to a scheduled stop with ma_sound_set_stop_time_*().
+    /// </summary>
+    /// <param name="pUserData">A pointer to user data associated with the callback.</param>
+    /// <param name="pSound">A pointer to the ma_sound that has reached the end.</param>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate void ma_sound_end_proc(IntPtr pUserData, ma_sound_ptr pSound);
 
+    /// <summary>
+    /// Callback for reading audio data from a procedural data source. This is invoked
+    /// each time the data source needs to generate audio data programmatically, such as
+    /// for waveform or noise generation, or for any custom data source that synthesizes
+    /// audio dynamically rather than reading from a file or memory buffer.
+    /// </summary>
+    /// <param name="pUserData">A pointer to user data associated with the callback.</param>
+    /// <param name="pFramesOut">A pointer to the output buffer that will receive the generated PCM frames.</param>
+    /// <param name="frameCount">The number of PCM frames to generate.</param>
+    /// <param name="channels">The number of audio channels.</param>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate void ma_procedural_data_source_proc(IntPtr pUserData, IntPtr pFramesOut, ma_uint64 frameCount, ma_uint32 channels);
 
+    /// <summary>
+    /// The callback for processing audio data from the device. This is fired by miniaudio
+    /// whenever the device needs to have more data delivered to a playback device, or
+    /// when a capture device has some data available. This is called as soon as the
+    /// backend asks for more data which means it may be called with inconsistent frame
+    /// counts. You cannot assume the callback will be fired with a consistent frame count.
+    /// </summary>
+    /// <param name="pDevice">A pointer to the relevant device.</param>
+    /// <param name="pOutput">A pointer to the output buffer that will receive audio data for playback.
+    /// This will be non-null for a playback or full-duplex device and null for a capture and loopback device.</param>
+    /// <param name="pInput">A pointer to the buffer containing input data from a recording device.
+    /// This will be non-null for a capture, full-duplex or loopback device and null for a playback device.</param>
+    /// <param name="frameCount">The number of PCM frames to process. Note that this will not necessarily
+    /// be equal to what was requested when the device was initialized. The periodSizeInFrames and
+    /// periodSizeInMilliseconds members of the device config are just hints.</param>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate void ma_device_data_proc(ma_device_ptr pDevice, IntPtr pOutput, IntPtr pInput, ma_uint32 frameCount);
 
+    /// <summary>
+    /// The notification callback for when the application should be notified of a change
+    /// to the device. This callback is used for notifying the application of changes such
+    /// as when the device has started, stopped, rerouted or an interruption has occurred.
+    /// Note that not all backends will post all notification types. Do not restart or
+    /// uninitialize the device from this callback.
+    /// </summary>
+    /// <param name="pNotification">A pointer to a structure containing information about the event.
+    /// Use the type member to discriminate against each of the notification types (started,
+    /// stopped, rerouted, interruption).</param>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate void ma_device_notification_proc(ma_device_notification_ptr pNotification);
 
+    /// <summary>
+    /// Callback for when the device has stopped. This will be called when the device is
+    /// stopped explicitly with ma_device_stop() and also called implicitly when the device
+    /// is stopped through external forces such as being unplugged or an internal error
+    /// occurring. Do not restart or uninitialize the device from the callback.
+    /// </summary>
+    /// <param name="pDevice">A pointer to the device that has just stopped.</param>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate void ma_stop_proc(ma_device_ptr pDevice);  /* DEPRECATED. Use ma_device_notification_proc instead. */
 
+    /// <summary>
+    /// The callback for handling device enumeration. This is fired from
+    /// ma_context_enumerate_devices(). The return value indicates whether
+    /// enumeration should continue. Return non-zero (MA_TRUE) to continue
+    /// enumerating, or zero (MA_FALSE) to stop.
+    /// </summary>
+    /// <param name="pContext">A pointer to the context performing the enumeration.</param>
+    /// <param name="deviceType">The type of the device being enumerated. This will always
+    /// be either ma_device_type_playback or ma_device_type_capture.</param>
+    /// <param name="pInfo">A pointer to a ma_device_info containing the ID and name of
+    /// the enumerated device. Note that this will not include detailed information about
+    /// the device, only basic information (ID and name).</param>
+    /// <param name="pUserData">The user data pointer passed into ma_context_enumerate_devices().</param>
+    /// <returns>MA_TRUE (non-zero) to continue enumeration or MA_FALSE (zero) to stop.</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate ma_bool32 ma_enum_devices_callback_proc(ma_context_ptr pContext, ma_device_type deviceType, ma_device_info pInfo, IntPtr pUserData);
 
+    /// <summary>
+    /// Callback for custom processing of engine output audio data. This is invoked by
+    /// the engine to allow custom processing or inspection of the final mixed audio
+    /// frames before they are sent to the device.
+    /// </summary>
+    /// <param name="pUserData">A pointer to user data associated with the callback.</param>
+    /// <param name="pFramesOut">A pointer to the buffer of output PCM frames to process.</param>
+    /// <param name="frameCount">The number of PCM frames in the buffer.</param>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate void ma_engine_process_proc(IntPtr pUserData, IntPtr pFramesOut, ma_uint64 frameCount);
 
+    /// <summary>
+    /// Callback for reading raw bytes from a decoder. This is invoked when the decoder
+    /// needs to read uncompressed audio data from the underlying source. Returns the
+    /// number of bytes read via the pBytesRead output parameter.
+    /// </summary>
+    /// <param name="pDecoder">A pointer to the decoder from which to read.</param>
+    /// <param name="pBufferOut">A pointer to the buffer that will receive the read bytes.</param>
+    /// <param name="bytesToRead">The number of bytes to read.</param>
+    /// <param name="pBytesRead">Output parameter that receives the number of bytes actually read.</param>
+    /// <returns>MA_SUCCESS if the read operation succeeded, or an appropriate error code otherwise.</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate ma_result ma_decoder_read_proc(ma_decoder_ptr pDecoder, IntPtr pBufferOut, size_t bytesToRead, out size_t pBytesRead);         /* Returns the number of bytes read. */
 
+    /// <summary>
+    /// Callback for seeking to a specific byte offset within a decoder. This allows
+    /// repositioning the read cursor to a specific location within the audio data.
+    /// </summary>
+    /// <param name="pDecoder">A pointer to the decoder to seek within.</param>
+    /// <param name="byteOffset">The byte offset to seek to, interpreted relative to the origin parameter.</param>
+    /// <param name="origin">The seek origin specifying how to interpret the byte offset.</param>
+    /// <returns>MA_SUCCESS if the seek operation succeeded, or an appropriate error code otherwise.</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate ma_result ma_decoder_seek_proc(ma_decoder_ptr pDecoder, ma_int64 byteOffset, ma_seek_origin origin);
 
+    /// <summary>
+    /// Callback for retrieving the current read cursor position of a decoder in bytes.
+    /// </summary>
+    /// <param name="pDecoder">A pointer to the decoder to query.</param>
+    /// <param name="pCursor">A reference that receives the current cursor position in bytes.</param>
+    /// <returns>MA_SUCCESS if the operation succeeded, or an appropriate error code otherwise.</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate ma_result ma_decoder_tell_proc(ma_decoder_ptr pDecoder, ref ma_int64 pCursor);
 
+    /// <summary>
+    /// Callback for retrieving the next data source in a data source chain. This is used
+    /// to support seamless chaining of data sources, allowing one data source to hand off
+    /// to another when it reaches the end of its data.
+    /// </summary>
+    /// <param name="pDataSource">A pointer to the current data source.</param>
+    /// <returns>A pointer to the next data source in the chain, or NULL if there is no next data source.</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate ma_data_source_ptr ma_data_source_get_next_proc(ma_data_source_ptr pDataSource);
 
+    /// <summary>
+    /// The callback for handling log messages from miniaudio. This is invoked whenever
+    /// miniaudio posts a log message, allowing the application to capture and handle
+    /// diagnostic output.
+    /// </summary>
+    /// <param name="pUserData">The user data pointer that was passed into ma_log_register_callback().</param>
+    /// <param name="level">The log level. This can be one of MA_LOG_LEVEL_DEBUG, MA_LOG_LEVEL_INFO,
+    /// MA_LOG_LEVEL_WARNING, or MA_LOG_LEVEL_ERROR.</param>
+    /// <param name="pMessage">A pointer to the null-terminated log message string.</param>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate void ma_log_callback_proc(IntPtr pUserData, ma_uint32 level, IntPtr pMessage);
 
+    /// <summary>
+    /// Extended processing callback for the audio node graph. This callback is used for
+    /// effects and nodes that process input and output at potentially different rates
+    /// (e.g. nodes that perform resampling). On input, pFrameCountOut is equal to the
+    /// capacity of the output buffer for each bus, whereas pFrameCountIn will be equal
+    /// to the number of PCM frames in each of the buffers in ppFramesIn. On output,
+    /// set pFrameCountOut to the number of PCM frames that were actually output and
+    /// set pFrameCountIn to the number of input frames that were consumed.
+    /// </summary>
+    /// <param name="pNode">A pointer to the node being processed.</param>
+    /// <param name="ppFramesIn">A pointer to an array of input buffer pointers, one per input bus.</param>
+    /// <param name="pFrameCountIn">A pointer to an array of frame counts for each input bus.</param>
+    /// <param name="ppFramesOut">A pointer to an array of output buffer pointers, one per output bus.</param>
+    /// <param name="pFrameCountOut">A pointer to an array of frame counts for each output bus.</param>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate void ma_node_vtable_process_proc(ma_node_ptr pNode, IntPtr ppFramesIn, IntPtr pFrameCountIn, IntPtr ppFramesOut, IntPtr pFrameCountOut);
 
+    /// <summary>
+    /// A callback for retrieving the number of input frames that are required to output
+    /// the specified number of output frames. This is useful for nodes that perform
+    /// resampling and helps miniaudio reduce latency by calculating the exact number
+    /// of input frames to read at a time instead of having to estimate. This is optional,
+    /// even for nodes that perform resampling.
+    /// </summary>
+    /// <param name="pNode">A pointer to the node being queried.</param>
+    /// <param name="outputFrameCount">The number of output frames that are desired.</param>
+    /// <param name="pInputFrameCount">A pointer that receives the number of input frames required.</param>
+    /// <returns>MA_SUCCESS if the operation succeeded, or an appropriate error code otherwise.</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate ma_result ma_node_vtable_get_required_input_frame_count_proc(ma_node_ptr pNode, ma_uint32 outputFrameCount, IntPtr pInputFrameCount);
 
+    /// <summary>
+    /// Custom memory allocation callback. Invoked by miniaudio when memory needs to
+    /// be allocated. This is the first member of the ma_allocation_callbacks structure.
+    /// </summary>
+    /// <param name="sz">The number of bytes to allocate.</param>
+    /// <param name="pUserData">A pointer to user data associated with the allocation callbacks.</param>
+    /// <returns>A pointer to the allocated memory block, or NULL if allocation failed.</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate IntPtr ma_allocation_callbacks_malloc_proc(size_t sz, IntPtr pUserData);
-    
+
+    /// <summary>
+    /// Custom memory reallocation callback. Invoked by miniaudio when an existing memory
+    /// block needs to be resized. This is the second member of the ma_allocation_callbacks
+    /// structure.
+    /// </summary>
+    /// <param name="p">A pointer to the existing memory block to reallocate, or NULL to allocate a new block.</param>
+    /// <param name="sz">The new number of bytes for the memory block.</param>
+    /// <param name="pUserData">A pointer to user data associated with the allocation callbacks.</param>
+    /// <returns>A pointer to the reallocated memory block, or NULL if reallocation failed.</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate IntPtr ma_allocation_callbacks_realloc_proc(IntPtr p, size_t sz, IntPtr pUserData);
-    
+
+    /// <summary>
+    /// Custom memory free callback. Invoked by miniaudio when an allocated memory block
+    /// should be released. This is the third member of the ma_allocation_callbacks structure.
+    /// </summary>
+    /// <param name="p">A pointer to the memory block to free.</param>
+    /// <param name="pUserData">A pointer to user data associated with the allocation callbacks.</param>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate void ma_allocation_callbacks_free_proc(IntPtr p, IntPtr pUserData);
 
+    /// <summary>
+    /// Callback for initializing a backend-specific context. This is part of the
+    /// ma_backend_callbacks structure and is invoked when a miniaudio context is
+    /// initialized with a specific backend.
+    /// </summary>
+    /// <param name="pContext">A pointer to the context to initialize.</param>
+    /// <param name="pConfig">The context configuration specifying initialization parameters.</param>
+    /// <param name="pCallbacks">A pointer to the backend callbacks structure to be populated.</param>
+    /// <returns>MA_SUCCESS if the context was initialized successfully, or an appropriate error code otherwise.</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate ma_result ma_backend_context_init_proc(ma_context_ptr pContext, ref ma_context_config pConfig, ref ma_backend_callbacks pCallbacks);
 
+    /// <summary>
+    /// Callback for uninitializing a backend-specific context. This is part of the
+    /// ma_backend_callbacks structure and is invoked when a miniaudio context is
+    /// being shut down.
+    /// </summary>
+    /// <param name="pContext">A pointer to the context to uninitialize.</param>
+    /// <returns>MA_SUCCESS if the context was uninitialized successfully, or an appropriate error code otherwise.</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate ma_result ma_backend_context_uninit_proc(ma_context_ptr pContext);
 
+    /// <summary>
+    /// Callback for enumerating available audio devices for a backend-specific context.
+    /// This is part of the ma_backend_callbacks structure and is invoked when
+    /// ma_context_enumerate_devices() is called.
+    /// </summary>
+    /// <param name="pContext">A pointer to the context performing the enumeration.</param>
+    /// <param name="callback">The callback to invoke for each enumerated device.</param>
+    /// <param name="pUserData">A pointer to user data to pass to the enumeration callback.</param>
+    /// <returns>MA_SUCCESS if the enumeration completed successfully, or an appropriate error code otherwise.</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate ma_result ma_backend_context_enumerate_devices_proc(ma_context_ptr pContext, ma_enum_devices_callback_proc callback, IntPtr pUserData);
 
+    /// <summary>
+    /// Callback for retrieving detailed information about a specific audio device from
+    /// a backend-specific context. This is part of the ma_backend_callbacks structure.
+    /// </summary>
+    /// <param name="pContext">A pointer to the context.</param>
+    /// <param name="deviceType">The type of device to get information for (playback or capture).</param>
+    /// <param name="pDeviceID">A pointer to the device ID identifying the specific device.</param>
+    /// <param name="pDeviceInfo">A pointer that receives the device information.</param>
+    /// <returns>MA_SUCCESS if the device information was retrieved successfully, or an appropriate error code otherwise.</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate ma_result ma_backend_context_get_device_info_proc(ma_context_ptr pContext, ma_device_type deviceType, ma_device_id_ptr pDeviceID, ma_device_info_ptr pDeviceInfo);
 
+    /// <summary>
+    /// Callback for initializing a backend-specific device. This is part of the
+    /// ma_backend_callbacks structure and is invoked when a device is initialized
+    /// with a specific backend.
+    /// </summary>
+    /// <param name="pDevice">A pointer to the device to initialize.</param>
+    /// <param name="pConfig">The device configuration specifying initialization parameters.</param>
+    /// <param name="pDescriptorPlayback">A pointer to the playback device descriptor, or NULL if not applicable.</param>
+    /// <param name="pDescriptorCapture">A pointer to the capture device descriptor, or NULL if not applicable.</param>
+    /// <returns>MA_SUCCESS if the device was initialized successfully, or an appropriate error code otherwise.</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate ma_result ma_backend_device_init_proc(ma_device_ptr pDevice, ref ma_device_config pConfig, ma_device_descriptor_ptr pDescriptorPlayback, ma_device_descriptor_ptr pDescriptorCapture);
 
+    /// <summary>
+    /// Callback for uninitializing a backend-specific device. This is part of the
+    /// ma_backend_callbacks structure and is invoked when a device is being shut down.
+    /// </summary>
+    /// <param name="pDevice">A pointer to the device to uninitialize.</param>
+    /// <returns>MA_SUCCESS if the device was uninitialized successfully, or an appropriate error code otherwise.</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate ma_result ma_backend_device_uninit_proc(ma_device_ptr pDevice);
 
+    /// <summary>
+    /// Callback for starting a backend-specific device. This is part of the
+    /// ma_backend_callbacks structure and is invoked when the audio device
+    /// should begin processing.
+    /// </summary>
+    /// <param name="pDevice">A pointer to the device to start.</param>
+    /// <returns>MA_SUCCESS if the device was started successfully, or an appropriate error code otherwise.</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate ma_result ma_backend_device_start_proc(ma_device_ptr pDevice);
 
+    /// <summary>
+    /// Callback for stopping a backend-specific device. This is part of the
+    /// ma_backend_callbacks structure and is invoked when the audio device
+    /// should stop processing.
+    /// </summary>
+    /// <param name="pDevice">A pointer to the device to stop.</param>
+    /// <returns>MA_SUCCESS if the device was stopped successfully, or an appropriate error code otherwise.</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate ma_result ma_backend_device_stop_proc(ma_device_ptr pDevice);
 
+    /// <summary>
+    /// Callback for reading audio frames from a backend-specific device. This is part
+    /// of the ma_backend_callbacks structure and is used for capture or full-duplex
+    /// devices.
+    /// </summary>
+    /// <param name="pDevice">A pointer to the device to read from.</param>
+    /// <param name="pFrames">A pointer to the buffer that will receive the captured PCM frames.</param>
+    /// <param name="frameCount">The number of PCM frames to read.</param>
+    /// <param name="pFramesRead">A pointer that receives the number of frames actually read.</param>
+    /// <returns>MA_SUCCESS if the read operation succeeded, or an appropriate error code otherwise.</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate ma_result ma_backend_device_read_proc(ma_device_ptr pDevice, IntPtr pFrames, ma_uint32 frameCount, IntPtr pFramesRead);
 
+    /// <summary>
+    /// Callback for writing audio frames to a backend-specific device. This is part
+    /// of the ma_backend_callbacks structure and is used for playback or full-duplex
+    /// devices.
+    /// </summary>
+    /// <param name="pDevice">A pointer to the device to write to.</param>
+    /// <param name="pFrames">A pointer to the buffer containing PCM frames to write.</param>
+    /// <param name="frameCount">The number of PCM frames to write.</param>
+    /// <param name="pFramesWritten">A pointer that receives the number of frames actually written.</param>
+    /// <returns>MA_SUCCESS if the write operation succeeded, or an appropriate error code otherwise.</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate ma_result ma_backend_device_write_proc(ma_device_ptr pDevice, IntPtr pFrames, ma_uint32 frameCount, IntPtr pFramesWritten);
 
+    /// <summary>
+    /// Callback for the backend-specific audio data loop. This is part of the
+    /// ma_backend_callbacks structure and implements the main audio processing loop
+    /// for the backend. It is responsible for feeding audio data to and from the
+    /// device on a separate audio thread.
+    /// </summary>
+    /// <param name="pDevice">A pointer to the device whose data loop should run.</param>
+    /// <returns>MA_SUCCESS if the data loop completed normally, or an appropriate error code otherwise.</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate ma_result ma_backend_device_dataloop_proc(ma_device_ptr pDevice);
 
+    /// <summary>
+    /// Callback for waking up the backend-specific audio data loop. This is part of
+    /// the ma_backend_callbacks structure and is used to signal the data loop thread
+    /// that it should wake up, typically when the device is being started or when
+    /// a state change has occurred.
+    /// </summary>
+    /// <param name="pDevice">A pointer to the device whose data loop should be woken up.</param>
+    /// <returns>MA_SUCCESS if the wakeup signal was sent successfully, or an appropriate error code otherwise.</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate ma_result ma_backend_device_dataloop_wakeup_proc(ma_device_ptr pDevice);
 
+    /// <summary>
+    /// Callback for retrieving device information from an initialized backend-specific
+    /// device. This is part of the ma_backend_callbacks structure and is optional.
+    /// If implemented by the backend, it allows for more efficient device information
+    /// retrieval compared to the context-level equivalent.
+    /// </summary>
+    /// <param name="pDevice">A pointer to the initialized device.</param>
+    /// <param name="type">The type of device information to retrieve (playback or capture).</param>
+    /// <param name="pDeviceInfo">A pointer that receives the device information.</param>
+    /// <returns>MA_SUCCESS if the device information was retrieved successfully, or an appropriate error code otherwise.</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate ma_result ma_backend_device_get_info_proc(ma_device_ptr pDevice, ma_device_type type, ma_device_info_ptr pDeviceInfo);
 
+    /// <summary>
+    /// Callback for reading PCM frames from a data source. This is a member of the
+    /// ma_data_source_vtable structure and is invoked when audio data needs to be
+    /// retrieved from the data source.
+    /// </summary>
+    /// <param name="pDataSource">A pointer to the data source to read from.</param>
+    /// <param name="pFramesOut">A pointer to the buffer that will receive the output PCM frames.</param>
+    /// <param name="frameCount">The number of PCM frames to read.</param>
+    /// <param name="pFramesRead">Output parameter that receives the number of frames actually read.</param>
+    /// <returns>MA_SUCCESS if the read operation succeeded, or an appropriate error code otherwise.
+    /// Return MA_AT_END if the end of the data source has been reached.</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate ma_result ma_data_source_vtable_read_proc(ma_data_source_ptr pDataSource, IntPtr pFramesOut, ma_uint64 frameCount, out UInt64 pFramesRead);
 
+    /// <summary>
+    /// Callback for seeking to a specific PCM frame index within a data source. This is
+    /// a member of the ma_data_source_vtable structure and is invoked when the data
+    /// source's read position needs to be changed.
+    /// </summary>
+    /// <param name="pDataSource">A pointer to the data source to seek within.</param>
+    /// <param name="frameIndex">The PCM frame index to seek to.</param>
+    /// <returns>MA_SUCCESS if the seek operation succeeded, or an appropriate error code otherwise.</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate ma_result ma_data_source_vtable_seek_proc(ma_data_source_ptr pDataSource, ma_uint64 frameIndex);
 
+    /// <summary>
+    /// Callback for retrieving the data format of a data source. This is a member of
+    /// the ma_data_source_vtable structure and provides the format, channel count,
+    /// sample rate, and channel map of the data source.
+    /// </summary>
+    /// <param name="pDataSource">A pointer to the data source to query.</param>
+    /// <param name="pFormat">Output parameter that receives the sample format of the data source.</param>
+    /// <param name="pChannels">Output parameter that receives the number of channels.</param>
+    /// <param name="pSampleRate">Output parameter that receives the sample rate in Hz.</param>
+    /// <param name="pChannelMap">A pointer to a buffer that receives the channel map.</param>
+    /// <param name="channelMapCap">The capacity of the channel map buffer.</param>
+    /// <returns>MA_SUCCESS if the format was retrieved successfully, or an appropriate error code otherwise.</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate ma_result ma_data_source_vtable_get_data_format_proc(ma_data_source_ptr pDataSource, out ma_format pFormat, out ma_uint32 pChannels, out ma_uint32 pSampleRate, ma_channel_ptr pChannelMap, size_t channelMapCap);
 
+    /// <summary>
+    /// Callback for retrieving the current cursor position of a data source in PCM
+    /// frames. This is a member of the ma_data_source_vtable structure.
+    /// </summary>
+    /// <param name="pDataSource">A pointer to the data source to query.</param>
+    /// <param name="pCursor">Output parameter that receives the current read cursor position in PCM frames.</param>
+    /// <returns>MA_SUCCESS if the cursor position was retrieved successfully. Return
+    /// MA_NOT_IMPLEMENTED if there is no notion of a cursor, in which case pCursor should be set to 0.</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate ma_result ma_data_source_vtable_get_cursor_proc(ma_data_source_ptr pDataSource, out UInt64 pCursor);
 
+    /// <summary>
+    /// Callback for retrieving the total length of a data source in PCM frames.
+    /// This is a member of the ma_data_source_vtable structure.
+    /// </summary>
+    /// <param name="pDataSource">A pointer to the data source to query.</param>
+    /// <param name="pLength">A pointer that receives the total length in PCM frames. Return
+    /// MA_NOT_IMPLEMENTED and set the value to 0 if there is no notion of a length or if the length is unknown.</param>
+    /// <returns>MA_SUCCESS if the length was retrieved successfully, or an appropriate error code otherwise.</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate ma_result ma_data_source_vtable_get_length_proc(ma_data_source_ptr pDataSource, IntPtr pLength);
 
+    /// <summary>
+    /// Callback for enabling or disabling looping on a data source. This is a member
+    /// of the ma_data_source_vtable structure and controls whether the data source
+    /// should loop when it reaches the end of its data.
+    /// </summary>
+    /// <param name="pDataSource">A pointer to the data source to configure.</param>
+    /// <param name="isLooping">Non-zero (MA_TRUE) to enable looping, zero (MA_FALSE) to disable looping.</param>
+    /// <returns>MA_SUCCESS if the looping state was set successfully, or an appropriate error code otherwise.</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate ma_result ma_data_source_vtable_set_looping_proc(ma_data_source_ptr pDataSource, ma_bool32 isLooping);
 
+    /// <summary>
+    /// Callback for processing audio through an effect node in the audio node graph.
+    /// This is invoked when an effect node needs to process audio data, applying
+    /// its effect transformation to the input and producing output. This is equivalent
+    /// to the onProcess callback in the ma_node_vtable structure, specifically for
+    /// effect-type nodes.
+    /// </summary>
+    /// <param name="pNode">A pointer to the effect node being processed.</param>
+    /// <param name="ppFramesIn">A pointer to an array of input buffer pointers, one per input bus.</param>
+    /// <param name="pFrameCountIn">A pointer to an array of input frame counts per bus.</param>
+    /// <param name="ppFramesOut">A pointer to an array of output buffer pointers, one per output bus.</param>
+    /// <param name="pFrameCountOut">A pointer to an array of output frame counts per bus.</param>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate void ma_effect_node_process_proc(ma_node_ptr pNode, IntPtr ppFramesIn, IntPtr pFrameCountIn, IntPtr ppFramesOut, IntPtr pFrameCountOut);
 
+    /// <summary>
+    /// Callback for writing raw bytes to an encoder. Encoders do not perform any format
+    /// conversion. If the target format does not support the input format, an error
+    /// will be returned.
+    /// </summary>
+    /// <param name="pEncoder">A pointer to the encoder to write to.</param>
+    /// <param name="pBufferIn">A pointer to the buffer containing raw bytes to encode.</param>
+    /// <param name="bytesToWrite">The number of bytes to write.</param>
+    /// <param name="pBytesWritten">Output parameter that receives the number of bytes actually written.</param>
+    /// <returns>MA_SUCCESS if the write operation succeeded, or an appropriate error code otherwise.</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate ma_result ma_encoder_write_proc(ma_encoder_ptr pEncoder, IntPtr pBufferIn, size_t bytesToWrite, out size_t pBytesWritten);
 
+    /// <summary>
+    /// Callback for seeking to a specific byte offset within an encoder. This allows
+    /// repositioning the write cursor to a specific location within the encoded data.
+    /// </summary>
+    /// <param name="pEncoder">A pointer to the encoder to seek within.</param>
+    /// <param name="offset">The byte offset to seek to, interpreted relative to the origin parameter.</param>
+    /// <param name="origin">The seek origin specifying how to interpret the offset.</param>
+    /// <returns>MA_SUCCESS if the seek operation succeeded, or an appropriate error code otherwise.</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate ma_result ma_encoder_seek_proc(ma_encoder_ptr pEncoder, ma_int64 offset, ma_seek_origin origin);
 
+    /// <summary>
+    /// Callback for initializing an encoder. This is invoked when the encoder needs
+    /// to set up its internal state and prepare for encoding operations.
+    /// </summary>
+    /// <param name="pEncoder">A pointer to the encoder to initialize.</param>
+    /// <returns>MA_SUCCESS if the encoder was initialized successfully, or an appropriate error code otherwise.</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate ma_result ma_encoder_init_proc(ma_encoder_ptr pEncoder);
 
+    /// <summary>
+    /// Callback for uninitializing an encoder. This is invoked when the encoder is
+    /// being shut down and should release any resources it has acquired.
+    /// </summary>
+    /// <param name="pEncoder">A pointer to the encoder to uninitialize.</param>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate void ma_encoder_uninit_proc(ma_encoder_ptr pEncoder);
 
+    /// <summary>
+    /// Callback for writing PCM frames to an encoder. This is invoked when the encoder
+    /// needs to encode audio data, taking raw PCM frames as input and producing encoded
+    /// output.
+    /// </summary>
+    /// <param name="pEncoder">A pointer to the encoder to write to.</param>
+    /// <param name="pFramesIn">A pointer to the buffer containing PCM frames to encode.</param>
+    /// <param name="frameCount">The number of PCM frames to encode.</param>
+    /// <param name="pFramesWritten">Output parameter that receives the number of frames actually written.</param>
+    /// <returns>MA_SUCCESS if the write operation succeeded, or an appropriate error code otherwise.</returns>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate ma_result ma_encoder_write_pcm_frames_proc(ma_encoder_ptr pEncoder, IntPtr pFramesIn, ma_uint64 frameCount, out ma_uint64 pFramesWritten);
 }

--- a/src/Native/MiniAudioNativeEnums.cs
+++ b/src/Native/MiniAudioNativeEnums.cs
@@ -51,498 +51,1094 @@ using System;
 namespace MiniAudioEx.Native
 {
     // ma_enums
+    /// <summary>
+    /// Result codes returned by miniaudio operations. A value of <c>success</c> (0) indicates
+    /// the operation completed successfully. Negative values represent specific error categories.
+    /// </summary>
     public enum ma_result
     {
+        /// <summary>Operation completed successfully.</summary>
         success = 0,
+        /// <summary>A generic error occurred during the operation.</summary>
         error = -1,  /* A generic error. */
+        /// <summary>One or more arguments passed to the function were invalid.</summary>
         invalid_args = -2,
+        /// <summary>The operation is not valid in the current context.</summary>
         invalid_operation = -3,
+        /// <summary>A memory allocation failed.</summary>
         out_of_memory = -4,
+        /// <summary>A value was out of the valid range.</summary>
         out_of_range = -5,
+        /// <summary>Access to the requested resource was denied.</summary>
         access_denied = -6,
+        /// <summary>The requested item does not exist.</summary>
         does_not_exist = -7,
+        /// <summary>The item already exists and cannot be created again.</summary>
         already_exists = -8,
+        /// <summary>Too many files are currently open.</summary>
         too_many_open_files = -9,
+        /// <summary>The file is invalid or corrupted.</summary>
         invalid_file = -10,
+        /// <summary>The data is too large for the operation.</summary>
         too_big = -11,
+        /// <summary>The file path exceeds the maximum allowed length.</summary>
         path_too_long = -12,
+        /// <summary>The name exceeds the maximum allowed length.</summary>
         name_too_long = -13,
+        /// <summary>The path does not point to a directory.</summary>
         not_directory = -14,
+        /// <summary>The path points to a directory rather than a file.</summary>
         is_directory = -15,
+        /// <summary>The directory is not empty and cannot be removed.</summary>
         directory_not_empty = -16,
+        /// <summary>Reached the end of the data. For decoders and data sources, this means no
+        /// more data is available and the stream has ended.</summary>
         at_end = -17,
+        /// <summary>No space left on the device.</summary>
         no_space = -18,
+        /// <summary>The resource is busy and cannot be used at this time.</summary>
         busy = -19,
+        /// <summary>An I/O error occurred during reading or writing.</summary>
         io_error = -20,
+        /// <summary>The operation was interrupted.</summary>
         interrupt = -21,
+        /// <summary>The requested resource is unavailable.</summary>
         unavailable = -22,
+        /// <summary>The resource is already in use by another operation.</summary>
         already_in_use = -23,
+        /// <summary>A bad memory address was encountered.</summary>
         bad_address = -24,
+        /// <summary>A seek operation failed due to an invalid position.</summary>
         bad_seek = -25,
+        /// <summary>A pipe operation failed.</summary>
         bad_pipe = -26,
+        /// <summary>A deadlock was detected.</summary>
         deadlock = -27,
+        /// <summary>Too many symbolic links were encountered.</summary>
         too_many_links = -28,
+        /// <summary>The requested feature or operation is not implemented.</summary>
         not_implemented = -29,
+        /// <summary>No message was available when one was expected.</summary>
         no_message = -30,
+        /// <summary>A received message was malformed.</summary>
         bad_message = -31,
+        /// <summary>No data is available for reading.</summary>
         no_data_available = -32,
+        /// <summary>The data is invalid or corrupted.</summary>
         invalid_data = -33,
+        /// <summary>The operation timed out.</summary>
         timeout = -34,
+        /// <summary>No network connection is available.</summary>
         no_network = -35,
+        /// <summary>The item is not unique when uniqueness was required.</summary>
         not_unique = -36,
+        /// <summary>The resource is not a socket.</summary>
         not_socket = -37,
+        /// <summary>No address was provided or available.</summary>
         no_address = -38,
+        /// <summary>A bad protocol was specified.</summary>
         bad_protocol = -39,
+        /// <summary>The requested protocol is unavailable.</summary>
         protocol_unavailable = -40,
+        /// <summary>The protocol is not supported.</summary>
         protocol_not_supported = -41,
+        /// <summary>The protocol family is not supported.</summary>
         protocol_family_not_supported = -42,
+        /// <summary>The address family is not supported.</summary>
         address_family_not_supported = -43,
+        /// <summary>Sockets are not supported on this platform.</summary>
         socket_not_supported = -44,
+        /// <summary>The connection was reset by the peer.</summary>
         connection_reset = -45,
+        /// <summary>The socket or connection is already connected.</summary>
         already_connected = -46,
+        /// <summary>The socket or connection is not connected.</summary>
         not_connected = -47,
+        /// <summary>The connection was refused by the remote host.</summary>
         connection_refused = -48,
+        /// <summary>No host was found for the given address.</summary>
         no_host = -49,
+        /// <summary>The operation is still in progress.</summary>
         in_progress = -50,
+        /// <summary>The operation was cancelled.</summary>
         cancelled = -51,
+        /// <summary>The requested memory region is already mapped.</summary>
         memory_already_mapped = -52,
 
         /* General non-standard errors. */
+        /// <summary>A CRC checksum mismatch was detected, indicating data corruption.</summary>
         crc_mismatch = -100,
 
         /* General miniaudio-specific errors. */
+        /// <summary>The requested sample format is not supported by the device or backend.</summary>
         format_not_supported = -200,
+        /// <summary>The device type (playback, capture, duplex, loopback) is not supported
+        /// by the backend.</summary>
         device_type_not_supported = -201,
+        /// <summary>The share mode (shared or exclusive) is not supported by the backend.</summary>
         share_mode_not_supported = -202,
+        /// <summary>No backend is available for audio I/O on this platform.</summary>
         no_backend = -203,
+        /// <summary>No device matching the requested criteria was found.</summary>
         no_device = -204,
+        /// <summary>The requested backend API was not found on the system.</summary>
         api_not_found = -205,
+        /// <summary>The device configuration is invalid.</summary>
         invalid_device_config = -206,
+        /// <summary>A loop was detected in a node graph or data pipeline.</summary>
         loop = -207,
+        /// <summary>The requested backend is not enabled in the build configuration.</summary>
         backend_not_enabled = -208,
 
         /* State errors. */
+        /// <summary>The device has not been initialized. Call a device init function first.</summary>
         device_not_initialized = -300,
+        /// <summary>The device has already been initialized and cannot be initialized again.</summary>
         device_already_initialized = -301,
+        /// <summary>The device has not been started. Call ma_device_start() first.</summary>
         device_not_started = -302,
+        /// <summary>The device has not been stopped. The operation requires the device to be
+        /// in a stopped state.</summary>
         device_not_stopped = -303,
 
         /* Operation errors. */
+        /// <summary>Initialization of the audio backend failed.</summary>
         failed_to_init_backend = -400,
+        /// <summary>Failed to open the backend-specific audio device.</summary>
         failed_to_open_backend_device = -401,
+        /// <summary>Failed to start the backend-specific audio device.</summary>
         failed_to_start_backend_device = -402,
+        /// <summary>Failed to stop the backend-specific audio device.</summary>
         failed_to_stop_backend_device = -403
     }
 
+    /// <summary>
+    /// Standard channel position maps for different audio formats and conventions.
+    /// Used by <c>ma_channel_map_init_standard()</c> to initialize channel maps according
+    /// to well-known standards.
+    /// </summary>
     public enum ma_standard_channel_map
     {
+        /// <summary>Microsoft channel ordering (e.g. FL, FR, FC, LFE, BL, BR). This is
+        /// the default.</summary>
         microsoft,
+        /// <summary>ALSA channel ordering used on Linux systems.</summary>
         alsa,
+        /// <summary>RFC 3551 channel ordering based on AIFF. For assigning channels to speaker positions according to RFC 3551.</summary>
         rfc3551,   /* Based off AIFF. */
+        /// <summary>FLAC channel ordering.</summary>
         flac,
+        /// <summary>Vorbis channel ordering.</summary>
         vorbis,
+        /// <summary>FreeBSD's sound(4) driver channel ordering.</summary>
         sound4,    /* FreeBSD's sound(4). */
+        /// <summary>sndio channel ordering (www.sndio.org/tips.html).</summary>
         sndio,     /* www.sndio.org/tips.html */
+        /// <summary>Web Audio API channel ordering. Only 1, 2, 4 and 6 channels are defined; gaps fill in with logical assumptions.</summary>
         webaudio = flac, /* https://webaudio.github.io/web-audio-api/#ChannelOrdering. Only 1, 2, 4 and 6 channels are defined, but can fill in the gaps with logical assumptions. */
+        /// <summary>The default standard channel map. Equivalent to <c>microsoft</c>.</summary>
         standard = microsoft
     }
 
+    /// <summary>
+    /// Types of notifications that can be sent from a device to the application
+    /// via the notification callback. These cover lifecycle events such as starting,
+    /// stopping, rerouting, and interruptions.
+    /// </summary>
     public enum ma_device_notification_type
     {
+        /// <summary>The device has just started and is now processing audio data.</summary>
         started,
+        /// <summary>The device has been stopped, either explicitly or due to an error
+        /// or disconnection.</summary>
         stopped,
+        /// <summary>The device has been rerouted to a different physical audio endpoint
+        /// (e.g. headphones unplugged, switching to speakers). Not all backends support
+        /// this notification.</summary>
         rerouted,
+        /// <summary>An audio interruption has begun (e.g. incoming phone call on mobile).
+        /// Currently implemented on iOS.</summary>
         interruption_began,
+        /// <summary>An audio interruption has ended and normal operation can resume.
+        /// Currently implemented on iOS.</summary>
         interruption_ended,
+        /// <summary>On Web Audio, fired after a user gesture has unlocked the ability
+        /// to play audio.</summary>
         unlocked
     }
 
+    /// <summary>
+    /// Specifies how the resource manager supplies data to a data source node.
+    /// Determines the type of connector used between the resource manager and the node.
+    /// </summary>
     public enum ma_resource_manager_data_supply_type
     {
+        /// <summary>The data supply type has not been initialized. Used for determining initialization state.</summary>
         unknown = 0,   /* Used for determining whether or the data supply has been initialized. */
+        /// <summary>Data is supplied as an encoded buffer using a ma_decoder connector for on-the-fly decoding.</summary>
         encoded,       /* Data supply is an encoded buffer. Connector is ma_decoder. */
+        /// <summary>Data is supplied as a pre-decoded buffer using a ma_audio_buffer connector.</summary>
         decoded,       /* Data supply is a decoded buffer. Connector is ma_audio_buffer. */
+        /// <summary>Data is supplied as a linked list of decoded pages using a ma_paged_audio_buffer connector.</summary>
         decoded_paged  /* Data supply is a linked list of decoded buffers. Connector is ma_paged_audio_buffer. */
     }
 
+    /// <summary>
+    /// Seek origin points for operations that move the read/write cursor
+    /// within a data stream, file, or audio buffer.
+    /// </summary>
     public enum ma_seek_origin
     {
+        /// <summary>Seek relative to the beginning of the data.</summary>
         start,
+        /// <summary>Seek relative to the current cursor position.</summary>
         current,
+        /// <summary>Seek relative to the end of the data. Not applicable to decoders.</summary>
         end  /* Not used by decoders. */
     }
 
+    /// <summary>
+    /// Performance profiles that influence the default buffer size and latency settings
+    /// when initializing a device. Used when no explicit buffer size is provided.
+    /// </summary>
     public enum ma_performance_profile
     {
+        /// <summary>Low latency. Results in a smaller default buffer size for reduced
+        /// audio delay, but higher CPU usage. This is the default.</summary>
         low_latency = 0,
+        /// <summary>Conservative. Results in a larger default buffer size for higher
+        /// reliability and lower CPU usage, but increased audio delay.</summary>
         conservative
     }
 
+    /// <summary>
+    /// Channel mixing modes used when converting between different channel counts.
+    /// Determines how channels are combined or dropped during conversion.
+    /// </summary>
     public enum ma_channel_mix_mode
     {
+        /// <summary>Simple rectangular averaging based on the spatial plane(s) each channel sits on. The default mixing mode.</summary>
         rectangular = 0,   /* Simple averaging based on the plane(s) the channel is sitting on. */
+        /// <summary>Simple mode dropping excess channels and zeroing out extra channels.</summary>
         simple,            /* Drop excess channels; zeroed out extra channels. */
+        /// <summary>Use custom weights specified in the ma_channel_converter_config for precise control over channel mixing.</summary>
         custom_weights,    /* Use custom weights specified in ma_channel_converter_config. */
+        /// <summary>The default channel mixing mode. Equivalent to <c>rectangular</c>.</summary>
         standard = rectangular // Actually called 'ma_channel_mix_mode_default' but 'default' is a reserved keyword in C#
     }
 
+    /// <summary>
+    /// Usage types for the WASAPI (Windows Audio Session API) backend. Controls how
+    /// Windows categorizes the audio stream, which affects the audio thread priority
+    /// and system mixing behavior.
+    /// </summary>
     public enum ma_wasapi_usage
     {
+        /// <summary>The default WASAPI usage. Equivalent to the shared-mode default for media or games.</summary>
         standard = 0, // Actually called 'ma_wasapi_usage_default' but 'default' is a reserved keyword in C#
+        /// <summary>Game audio. Uses the AUDCLNT_STREAMFLAGS_RATEADJUST flag for
+        /// games category processing.</summary>
         games,
+        /// <summary>Professional audio. Uses AUDCLNT_STREAMFLAGS_RATEADJUST for
+        /// pro audio category processing.</summary>
         pro_audio,
     }
 
+    /// <summary>
+    /// Stream types for the OpenSL ES backend on Android. Corresponds to Android's
+    /// SL_ANDROID_STREAM_* constants and controls how the system treats the audio
+    /// stream (e.g. volume control, routing).
+    /// </summary>
     public enum ma_opensl_stream_type
     {
+        /// <summary>Leaves the stream type unset, using the system default. Equivalent to the default SL_ANDROID_STREAM.</summary>
         standard = 0,              /* Leaves the stream type unset. */
+        /// <summary>SL_ANDROID_STREAM_VOICE. For voice call audio.</summary>
         voice,                    /* SL_ANDROID_STREAM_VOICE */
+        /// <summary>SL_ANDROID_STREAM_SYSTEM. For system sounds.</summary>
         system,                   /* SL_ANDROID_STREAM_SYSTEM */
+        /// <summary>SL_ANDROID_STREAM_RING. For ringtone audio.</summary>
         ring,                     /* SL_ANDROID_STREAM_RING */
+        /// <summary>SL_ANDROID_STREAM_MEDIA. For music and media playback.</summary>
         media,                    /* SL_ANDROID_STREAM_MEDIA */
+        /// <summary>SL_ANDROID_STREAM_ALARM. For alarm audio.</summary>
         alarm,                    /* SL_ANDROID_STREAM_ALARM */
+        /// <summary>SL_ANDROID_STREAM_NOTIFICATION. For notification sounds.</summary>
         notification              /* SL_ANDROID_STREAM_NOTIFICATION */
     }
 
+    /// <summary>
+    /// Recording presets for the OpenSL ES backend on Android. Corresponds to
+    /// Android's SL_ANDROID_RECORDING_PRESET_* constants and controls audio
+    /// processing applied to the microphone input.
+    /// </summary>
     public enum ma_opensl_recording_preset
     {
+        /// <summary>Leaves the input preset unset, using the system default.</summary>
         standard = 0,         /* Leaves the input preset unset. */
+        /// <summary>SL_ANDROID_RECORDING_PRESET_GENERIC. No special processing.</summary>
         generic,             /* SL_ANDROID_RECORDING_PRESET_GENERIC */
+        /// <summary>SL_ANDROID_RECORDING_PRESET_CAMCORDER. Optimized for video recording.</summary>
         camcorder,           /* SL_ANDROID_RECORDING_PRESET_CAMCORDER */
+        /// <summary>SL_ANDROID_RECORDING_PRESET_VOICE_RECOGNITION. Optimized for
+        /// speech recognition.</summary>
         voice_recognition,   /* SL_ANDROID_RECORDING_PRESET_VOICE_RECOGNITION */
+        /// <summary>SL_ANDROID_RECORDING_PRESET_VOICE_COMMUNICATION. Optimized for
+        /// voice communication (e.g. VoIP).</summary>
         voice_communication, /* SL_ANDROID_RECORDING_PRESET_VOICE_COMMUNICATION */
+        /// <summary>SL_ANDROID_RECORDING_PRESET_UNPROCESSED. Raw, unprocessed
+        /// microphone input.</summary>
         voice_unprocessed    /* SL_ANDROID_RECORDING_PRESET_UNPROCESSED */
     }
 
+    /// <summary>
+    /// Usage types for the AAudio backend on Android. Corresponds to Android's
+    /// AAUDIO_USAGE_* constants and controls how the system treats the audio stream.
+    /// </summary>
     public enum ma_aaudio_usage
     {
+        /// <summary>Leaves the usage type unset, using the system default.</summary>
         standard = 0,                    /* Leaves the usage type unset. */
+        /// <summary>AAUDIO_USAGE_MEDIA. For music and media playback.</summary>
         media,                          /* AAUDIO_USAGE_MEDIA */
+        /// <summary>AAUDIO_USAGE_VOICE_COMMUNICATION. For voice calls and VoIP.</summary>
         voice_communication,            /* AAUDIO_USAGE_VOICE_COMMUNICATION */
+        /// <summary>AAUDIO_USAGE_VOICE_COMMUNICATION_SIGNALLING. For signalling
+        /// associated with voice communication.</summary>
         voice_communication_signalling, /* AAUDIO_USAGE_VOICE_COMMUNICATION_SIGNALLING */
+        /// <summary>AAUDIO_USAGE_ALARM. For alarm sounds.</summary>
         alarm,                          /* AAUDIO_USAGE_ALARM */
+        /// <summary>AAUDIO_USAGE_NOTIFICATION. For notification sounds.</summary>
         notification,                   /* AAUDIO_USAGE_NOTIFICATION */
+        /// <summary>AAUDIO_USAGE_NOTIFICATION_RINGTONE. For ringtone notifications.</summary>
         notification_ringtone,          /* AAUDIO_USAGE_NOTIFICATION_RINGTONE */
+        /// <summary>AAUDIO_USAGE_NOTIFICATION_EVENT. For event notifications.</summary>
         notification_event,             /* AAUDIO_USAGE_NOTIFICATION_EVENT */
+        /// <summary>AAUDIO_USAGE_ASSISTANCE_ACCESSIBILITY. For accessibility
+        /// assistance.</summary>
         assistance_accessibility,       /* AAUDIO_USAGE_ASSISTANCE_ACCESSIBILITY */
+        /// <summary>AAUDIO_USAGE_ASSISTANCE_NAVIGATION_GUIDANCE. For navigation
+        /// guidance.</summary>
         assistance_navigation_guidance, /* AAUDIO_USAGE_ASSISTANCE_NAVIGATION_GUIDANCE */
+        /// <summary>AAUDIO_USAGE_ASSISTANCE_SONIFICATION. For sonification of
+        /// assistive data.</summary>
         assistance_sonification,        /* AAUDIO_USAGE_ASSISTANCE_SONIFICATION */
+        /// <summary>AAUDIO_USAGE_GAME. For game audio.</summary>
         game,                           /* AAUDIO_USAGE_GAME */
+        /// <summary>AAUDIO_USAGE_ASSISTANT. For virtual assistant audio.</summary>
         assitant,                       /* AAUDIO_USAGE_ASSISTANT */
+        /// <summary>AAUDIO_SYSTEM_USAGE_EMERGENCY. For emergency audio.</summary>
         emergency,                      /* AAUDIO_SYSTEM_USAGE_EMERGENCY */
+        /// <summary>AAUDIO_SYSTEM_USAGE_SAFETY. For safety-related audio.</summary>
         safety,                         /* AAUDIO_SYSTEM_USAGE_SAFETY */
+        /// <summary>AAUDIO_SYSTEM_USAGE_VEHICLE_STATUS. For vehicle status audio.</summary>
         vehicle_status,                 /* AAUDIO_SYSTEM_USAGE_VEHICLE_STATUS */
+        /// <summary>AAUDIO_SYSTEM_USAGE_ANNOUNCEMENT. For announcement audio.</summary>
         announcement                    /* AAUDIO_SYSTEM_USAGE_ANNOUNCEMENT */
     }
 
+    /// <summary>
+    /// Content types for the AAudio backend on Android. Corresponds to Android's
+    /// AAUDIO_CONTENT_TYPE_* constants and describes the type of audio content
+    /// being played.
+    /// </summary>
     public enum ma_aaudio_content_type
     {
+        /// <summary>Leaves the content type unset, using the system default.</summary>
         standard = 0,             /* Leaves the content type unset. */
+        /// <summary>AAUDIO_CONTENT_TYPE_SPEECH. For spoken word content.</summary>
         speech,                  /* AAUDIO_CONTENT_TYPE_SPEECH */
+        /// <summary>AAUDIO_CONTENT_TYPE_MUSIC. For music content.</summary>
         music,                   /* AAUDIO_CONTENT_TYPE_MUSIC */
+        /// <summary>AAUDIO_CONTENT_TYPE_MOVIE. For movie and video content.</summary>
         movie,                   /* AAUDIO_CONTENT_TYPE_MOVIE */
+        /// <summary>AAUDIO_CONTENT_TYPE_SONIFICATION. For sonification content
+        /// (audio representations of data).</summary>
         sonification             /* AAUDIO_CONTENT_TYPE_SONIFICATION */
     }
 
+    /// <summary>
+    /// Input presets for the AAudio backend on Android. Corresponds to Android's
+    /// AAUDIO_INPUT_PRESET_* constants and controls audio processing applied to
+    /// the microphone input.
+    /// </summary>
     public enum ma_aaudio_input_preset
     {
+        /// <summary>Leaves the input preset unset, using the system default.</summary>
         standard = 0,             /* Leaves the input preset unset. */
+        /// <summary>AAUDIO_INPUT_PRESET_GENERIC. No special processing.</summary>
         generic,                 /* AAUDIO_INPUT_PRESET_GENERIC */
+        /// <summary>AAUDIO_INPUT_PRESET_CAMCORDER. Optimized for video recording.</summary>
         camcorder,               /* AAUDIO_INPUT_PRESET_CAMCORDER */
+        /// <summary>AAUDIO_INPUT_PRESET_VOICE_RECOGNITION. Optimized for speech
+        /// recognition.</summary>
         voice_recognition,       /* AAUDIO_INPUT_PRESET_VOICE_RECOGNITION */
+        /// <summary>AAUDIO_INPUT_PRESET_VOICE_COMMUNICATION. Optimized for voice
+        /// communication (e.g. VoIP).</summary>
         voice_communication,     /* AAUDIO_INPUT_PRESET_VOICE_COMMUNICATION */
+        /// <summary>AAUDIO_INPUT_PRESET_UNPROCESSED. Raw, unprocessed microphone input.</summary>
         unprocessed,             /* AAUDIO_INPUT_PRESET_UNPROCESSED */
+        /// <summary>AAUDIO_INPUT_PRESET_VOICE_PERFORMANCE. Optimized for vocal
+        /// performance (e.g. karaoke).</summary>
         voice_performance        /* AAUDIO_INPUT_PRESET_VOICE_PERFORMANCE */
     }
 
+    /// <summary>
+    /// Capture policies for the AAudio backend on Android. Corresponds to Android's
+    /// AAUDIO_ALLOW_CAPTURE_BY_* constants and controls which apps can capture
+    /// audio from this stream.
+    /// </summary>
     public enum ma_aaudio_allowed_capture_policy
     {
+        /// <summary>Leaves the allowed capture policy unset, using the system default.</summary>
         standard = 0,            /* Leaves the allowed capture policy unset. */
+        /// <summary>AAUDIO_ALLOW_CAPTURE_BY_ALL. Any app can capture audio
+        /// from this stream.</summary>
         by_all,                 /* AAUDIO_ALLOW_CAPTURE_BY_ALL */
+        /// <summary>AAUDIO_ALLOW_CAPTURE_BY_SYSTEM. Only system apps can capture
+        /// audio from this stream.</summary>
         by_system,              /* AAUDIO_ALLOW_CAPTURE_BY_SYSTEM */
+        /// <summary>AAUDIO_ALLOW_CAPTURE_BY_NONE. No apps can capture audio
+        /// from this stream.</summary>
         by_none                 /* AAUDIO_ALLOW_CAPTURE_BY_NONE */
     }
 
+    /// <summary>
+    /// Resampling algorithms used when the device sample rate differs from the
+    /// source sample rate. The linear algorithm is the default and provides
+    /// a good balance of quality and performance.
+    /// </summary>
     public enum ma_resample_algorithm
     {
+        /// <summary>Linear resampling with optional low-pass filtering. Fastest speed, lowest quality. This is the default.</summary>
         linear = 0,    /* Fastest, lowest quality. Optional low-pass filtering. Default. */
+        /// <summary>Custom resampling algorithm. A user-provided backend vtable
+        /// must be supplied in the resampler config.</summary>
         custom,
     }
 
+    /// <summary>
+    /// Share modes for audio devices. Controls whether the device is shared with
+    /// other applications or used exclusively.
+    /// </summary>
     public enum ma_share_mode
     {
+        /// <summary>Shared mode. The audio device is shared with other applications.
+        /// The system mixer will handle format conversion and mixing. This is the
+        /// default and most compatible mode.</summary>
         shared = 0,
+        /// <summary>Exclusive mode. The application has exclusive access to the
+        /// audio device. Provides lower latency and bit-perfect output, but prevents
+        /// other applications from using the device. Not supported by all backends.</summary>
         exclusive
     }
 
+    /// <summary>
+    /// Distance attenuation models for 3D spatialization. Determines how the volume
+    /// of a sound decreases as it moves away from the listener.
+    /// </summary>
     public enum ma_attenuation_model
     {
+        /// <summary>No distance attenuation and no spatialization. The sound plays
+        /// at full volume regardless of distance.</summary>
         none,          /* No distance attenuation and no spatialization. */
+        /// <summary>Inverse distance attenuation. Volume decreases as 1/distance.
+        /// Equivalent to OpenAL's AL_INVERSE_DISTANCE_CLAMPED.</summary>
         inverse,       /* Equivalent to OpenAL's AL_INVERSE_DISTANCE_CLAMPED. */
+        /// <summary>Linear attenuation. Volume decreases linearly with distance.
+        /// Equivalent to OpenAL's AL_LINEAR_DISTANCE_CLAMPED.</summary>
         linear,        /* Linear attenuation. Equivalent to OpenAL's AL_LINEAR_DISTANCE_CLAMPED. */
+        /// <summary>Exponential attenuation. Volume decreases exponentially with
+        /// distance. Equivalent to OpenAL's AL_EXPONENT_DISTANCE_CLAMPED.</summary>
         exponential    /* Exponential attenuation. Equivalent to OpenAL's AL_EXPONENT_DISTANCE_CLAMPED. */
     }
 
+    /// <summary>
+    /// Audio backends listed in priority order. The first available backend
+    /// on a given platform will be used automatically. The null backend is always
+    /// last and serves as the terminator for backend enumeration.
+    /// </summary>
     /* Backend enums must be in priority order. */
     public enum ma_backend
     {
+        /// <summary>Windows Audio Session API (WASAPI). The primary backend on
+        /// Windows with support for both shared and exclusive modes.</summary>
         wasapi,
+        /// <summary>DirectSound. A legacy Windows backend with broad compatibility
+        /// but higher latency than WASAPI.</summary>
         dsound,
+        /// <summary>Windows Multimedia (WinMM). A legacy Windows backend with
+        /// the broadest compatibility but highest latency.</summary>
         winmm,
+        /// <summary>Core Audio. The primary backend on macOS and iOS.</summary>
         coreaudio,
+        /// <summary>sndio. Audio backend used on OpenBSD and some other BSD systems.</summary>
         sndio,
+        /// <summary>audio(4). Audio backend for NetBSD and OpenBSD systems.</summary>
         audio4,
+        /// <summary>OSS (Open Sound System). Audio backend for FreeBSD and
+        /// DragonFly BSD.</summary>
         oss,
+        /// <summary>PulseAudio. A common Linux audio server providing per-application
+        /// volume control and network transparency.</summary>
         pulseaudio,
+        /// <summary>ALSA (Advanced Linux Sound Architecture). The low-level audio
+        /// API on Linux providing direct hardware access.</summary>
         alsa,
+        /// <summary>JACK Audio Connection Kit. A professional-grade low-latency
+        /// audio server for Linux and macOS.</summary>
         jack,
+        /// <summary>AAudio. The modern low-latency audio API on Android (SDK 27+).</summary>
         aaudio,
+        /// <summary>OpenSL ES. The legacy audio API on Android with broader
+        /// compatibility.</summary>
         opensl,
+        /// <summary>Web Audio API. Used within web browsers via Emscripten.</summary>
         webaudio,
+        /// <summary>Custom backend using user-provided callbacks defined in the context config.</summary>
         custom,  /* <-- Custom backend, with callbacks defined by the context config. */
+        /// <summary>Null backend. Always the last item with the lowest priority, serving as the terminator for backend enumeration.</summary>
         nill     /* <-- Must always be the last item. Lowest priority, and used as the terminator for backend enumeration. */
     }
 
+    /// <summary>
+    /// Sample formats for PCM audio data. Determines the bit depth and data type
+    /// of individual samples. Values are explicitly assigned to serve as keys
+    /// into lookup tables.
+    /// </summary>
     public enum ma_format
     {
         /*
         I like to keep these explicitly defined because they're used as a key into a lookup table. When items are
         added to this, make sure there are no gaps and that they're added to the lookup table in ma_get_bytes_per_sample().
         */
+        /// <summary>Unknown or unspecified format. Used as the default output format for decoders and for error indication.</summary>
         unknown = 0,     /* Mainly used for indicating an error, but also used as the default for the output format for decoders. */
+        /// <summary>Unsigned 8-bit integer. Range: 0 to 255 with a midpoint of 128.</summary>
         u8 = 1,
+        /// <summary>Signed 16-bit integer. The most widely supported format across
+        /// all backends. Range: -32768 to 32767.</summary>
         s16 = 2,     /* Seems to be the most widely supported format. */
+        /// <summary>Signed 24-bit integer, tightly packed. 3 bytes per sample.</summary>
         s24 = 3,     /* Tightly packed. 3 bytes per sample. */
+        /// <summary>Signed 32-bit integer. Range: -2147483648 to 2147483647.</summary>
         s32 = 4,
+        /// <summary>32-bit floating point. Range: -1.0 to 1.0. Used internally
+        /// by the node graph system.</summary>
         f32 = 5,
+        /// <summary>The number of defined format values. Used as an array size in lookup tables.</summary>
         count
     }
 
+    /// <summary>
+    /// Pan modes for stereo panning. Controls how the audio signal is distributed
+    /// between the left and right channels.
+    /// </summary>
     public enum ma_pan_mode
     {
+        /// <summary>Simple balance without blending one side into the other. Compatible with other popular audio engines. This is the default.</summary>
         balance = 0,    /* Does not blend one side with the other. Technically just a balance. Compatible with other popular audio engines and therefore the default. */
+        /// <summary>A true pan. The sound from one side will "move" to the other side
+        /// and blend with it, creating a more natural stereo field than simple balance.</summary>
         pan             /* A true pan. The sound from one side will "move" to the other side and blend with it. */
     }
 
+    /// <summary>
+    /// Positioning modes for 3D spatialization. Determines how the position of a
+    /// sound source is interpreted relative to the listener.
+    /// </summary>
     public enum ma_positioning
     {
+        /// <summary>Absolute positioning. The sound's position is specified in
+        /// world-space coordinates.</summary>
         absolute,
+        /// <summary>Relative positioning. The sound's position is specified relative
+        /// to the listener's position.</summary>
         relative
     }
 
+    /// <summary>
+    /// Handedness of the coordinate system used for 3D spatialization. Determines
+    /// the orientation of the forward direction on the Z axis.
+    /// </summary>
     public enum ma_handedness
     {
+        /// <summary>Right-handed coordinate system. Forward is -1 on the Z axis.
+        /// This is the default.</summary>
         right,
+        /// <summary>Left-handed coordinate system. Forward is +1 on the Z axis.</summary>
         left
     }
 
+    /// <summary>
+    /// Allocation type identifiers used by miniaudio's internal memory tracking.
+    /// Each value corresponds to a specific data structure or object type that
+    /// miniaudio allocates internally.
+    /// </summary>
     public enum ma_allocation_type
     {
+        /// <summary>Async notification object.</summary>
         async_notification,
+        /// <summary>Biquad filter coefficient set.</summary>
         biquad_coefficient,
+        /// <summary>Biquad filter with configurable order.</summary>
         biquad,
+        /// <summary>Band-pass filter with configurable order.</summary>
         bpf,
+        /// <summary>Second order band-pass filter.</summary>
         bpf2,
+        /// <summary>Band-pass filter node.</summary>
         bpf_node,
+        /// <summary>Channel data buffer.</summary>
         channel,
+        /// <summary>Audio context.</summary>
         context,
+        /// <summary>Data source object.</summary>
         data_source,
+        /// <summary>Data source node.</summary>
         data_source_node,
+        /// <summary>Data source virtual table.</summary>
         data_source_vtable,
+        /// <summary>Audio decoder.</summary>
         decoder,
+        /// <summary>Decoding backend virtual table.</summary>
         decoding_backend_vtable,
+        /// <summary>Delay/echo effect.</summary>
         delay,
+        /// <summary>Delay node.</summary>
         delay_node,
+        /// <summary>Audio device.</summary>
         device,
+        /// <summary>Capture device component.</summary>
         device_capture,
+        /// <summary>Device descriptor.</summary>
         device_descriptor,
+        /// <summary>Device ID.</summary>
         device_id,
+        /// <summary>Device information structure.</summary>
         device_info,
+        /// <summary>Device notification.</summary>
         device_notification,
+        /// <summary>Playback device component.</summary>
         device_playback,
+        /// <summary>Device resampling component.</summary>
         device_resampling,
+        /// <summary>Effect node.</summary>
         effect_node,
+        /// <summary>Audio encoder.</summary>
         encoder,
+        /// <summary>Audio engine.</summary>
         engine,
+        /// <summary>Volume fader.</summary>
         fader,
+        /// <summary>Synchronization fence.</summary>
         fence,
+        /// <summary>Volume gainer (smooth gain transitions).</summary>
         gainer,
+        /// <summary>Second order high-shelf filter.</summary>
         hishelf2,
+        /// <summary>High-shelf filter node.</summary>
         hishelf_node,
+        /// <summary>High-pass filter with configurable order.</summary>
         hpf,
+        /// <summary>First order high-pass filter.</summary>
         hpf1,
+        /// <summary>Second order high-pass filter.</summary>
         hpf2,
+        /// <summary>High-pass filter node.</summary>
         hpf_node,
+        /// <summary>Logging system.</summary>
         log,
+        /// <summary>Second order low-shelf filter.</summary>
         loshelf2,
+        /// <summary>Low-shelf filter node.</summary>
         loshelf_node,
+        /// <summary>Low-pass filter with configurable order.</summary>
         lpf,
+        /// <summary>First order low-pass filter.</summary>
         lpf1,
+        /// <summary>Second order low-pass filter.</summary>
         lpf2,
+        /// <summary>Low-pass filter node.</summary>
         lpf_node,
+        /// <summary>Node in a node graph.</summary>
         node,
+        /// <summary>Base node component.</summary>
         node_base,
+        /// <summary>Node graph for audio processing.</summary>
         node_graph,
+        /// <summary>Node input bus.</summary>
         node_input_bus,
+        /// <summary>Node output bus.</summary>
         node_output_bus,
+        /// <summary>Node virtual table.</summary>
         node_vtable,
+        /// <summary>Noise generator.</summary>
         noise,
+        /// <summary>Second order notch filter.</summary>
         notch2,
+        /// <summary>Notch filter node.</summary>
         notch_node,
+        /// <summary>Stereo panner.</summary>
         panner,
+        /// <summary>Second order peaking EQ filter.</summary>
         peak2,
+        /// <summary>Peaking EQ filter node.</summary>
         peak_node,
+        /// <summary>Procedural data source.</summary>
         procedural_data_source,
+        /// <summary>Pulse wave generator.</summary>
         pulsewave,
+        /// <summary>Resampling backend virtual table.</summary>
         resampling_backend_vtable,
+        /// <summary>Resource manager.</summary>
         resource_manager,
+        /// <summary>Resource manager data source.</summary>
         resource_manager_data_source,
+        /// <summary>Sound object in the engine.</summary>
         sound,
+        /// <summary>Inlined sound object.</summary>
         sound_inlined,
+        /// <summary>Sound group for collective control.</summary>
         sound_group,
+        /// <summary>3D spatializer effect.</summary>
         spatializer,
+        /// <summary>Spatializer listener.</summary>
         spatializer_listener,
+        /// <summary>Splitter node for routing audio.</summary>
         splitter_node,
+        /// <summary>Memory stack.</summary>
         stack,
+        /// <summary>Virtual file system.</summary>
         vfs,
+        /// <summary>Waveform generator.</summary>
         waveform,
     }
 
+    /// <summary>
+    /// Device type flags indicating the direction(s) of audio data flow.
+    /// Can be combined with bitwise OR for duplex operation.
+    /// </summary>
     public enum ma_device_type
     {
+        /// <summary>Playback device. Outputs audio to speakers or headphones.</summary>
         playback = 1,
+        /// <summary>Capture device. Records audio from a microphone or line-in.</summary>
         capture = 2,
+        /// <summary>Duplex device. Supports simultaneous playback and capture.
+        /// Equivalent to <c>playback | capture</c>.</summary>
         duplex = playback | capture, /* 3 */
+        /// <summary>Loopback device. Captures audio that is being played by the
+        /// system (what you hear).</summary>
         loopback = 4
     }
 
+    /// <summary>
+    /// Mono expansion modes for converting a mono signal to multi-channel output.
+    /// Determines how a single channel of audio is distributed across multiple
+    /// output channels.
+    /// </summary>
     public enum ma_mono_expansion_mode
     {
+        /// <summary>Duplicate the mono signal to all output channels. This is the default.</summary>
         duplicate = 0,   /* The default. */
+        /// <summary>Average the mono channel across all channels, reducing volume
+        /// to maintain consistent loudness.</summary>
         average,         /* Average the mono channel across all channels. */
+        /// <summary>Duplicate the mono signal to the left and right channels only,
+        /// leaving other channels silent.</summary>
         stereo_only,     /* Duplicate to the left and right channels only and ignore the others. */
+        /// <summary>The default mono expansion mode. Equivalent to <c>duplicate</c>.</summary>
         standard = duplicate
     }
 
+    /// <summary>
+    /// Thread priority levels for audio worker threads. Higher values indicate
+    /// higher scheduling priority. The default priority is <c>highest</c> (0).
+    /// </summary>
     public enum ma_thread_priority
     {
+        /// <summary>Idle priority. Lowest possible scheduling priority.</summary>
         idle = -5,
+        /// <summary>Lowest priority above idle.</summary>
         lowest = -4,
+        /// <summary>Low priority.</summary>
         low = -3,
+        /// <summary>Normal priority.</summary>
         normal = -2,
+        /// <summary>High priority.</summary>
         high = -1,
+        /// <summary>Highest priority. This is the default for audio threads.</summary>
         highest = 0,
+        /// <summary>Realtime priority. The highest possible scheduling priority,
+        /// only recommended for professional audio applications.</summary>
         realtime = 1,
+        /// <summary>The default thread priority. Equivalent to <c>highest</c>.</summary>
         standard = 0
     }
 
+    /// <summary>
+    /// iOS/tvOS/watchOS audio session categories for the Core Audio backend.
+    /// Corresponds to Apple's AVAudioSessionCategory constants and controls how
+    /// audio interacts with other apps and system services.
+    /// </summary>
     public enum ma_ios_session_category
     {
         standard = 0,        /* AVAudioSessionCategoryPlayAndRecord. */
+        /// <summary>Leave the session category unchanged from the system default.</summary>
         none,               /* Leave the session category unchanged. */
+        /// <summary>AVAudioSessionCategoryAmbient. Audio plays with the ring/silent
+        /// switch and screen lock. Mixes with other audio.</summary>
         ambient,            /* AVAudioSessionCategoryAmbient */
+        /// <summary>AVAudioSessionCategorySoloAmbient. Similar to Ambient but
+        /// silences other audio.</summary>
         solo_ambient,       /* AVAudioSessionCategorySoloAmbient */
+        /// <summary>AVAudioSessionCategoryPlayback. Audio plays even with the
+        /// ring/silent switch set to silent and the screen locked.</summary>
         playback,           /* AVAudioSessionCategoryPlayback */
+        /// <summary>AVAudioSessionCategoryRecord. Audio recording only; silences
+        /// playback audio.</summary>
         record,             /* AVAudioSessionCategoryRecord */
+        /// <summary>AVAudioSessionCategoryPlayAndRecord. Simultaneous playback
+        /// and recording. This is the default.</summary>
         play_and_record,    /* AVAudioSessionCategoryPlayAndRecord */
+        /// <summary>AVAudioSessionCategoryMultiRoute. Supports simultaneous
+        /// output to multiple audio routes.</summary>
         multi_route         /* AVAudioSessionCategoryMultiRoute */
     }
 
+    /// <summary>
+    /// Dither modes for format conversion. Dithering adds a small amount of noise
+    /// to reduce quantization distortion when converting to lower bit depths.
+    /// </summary>
     public enum ma_dither_mode
     {
+        /// <summary>No dithering. Fastest but may introduce quantization artifacts.</summary>
         none = 0,
+        /// <summary>Rectangular dither. Adds uniform white noise to mask
+        /// quantization distortion.</summary>
         rectangle,
+        /// <summary>Triangular dither. Adds triangular probability density noise
+        /// for improved noise shaping compared to rectangular dither.</summary>
         triangle
     }
 
+    /// <summary>
+    /// Audio encoding and container formats supported by miniaudio for both
+    /// decoding and encoding operations.
+    /// </summary>
     public enum ma_encoding_format
     {
+        /// <summary>Unknown or unspecified format.</summary>
         unknown = 0,
+        /// <summary>WAV (Waveform Audio File Format). Uncompressed PCM data
+        /// stored in a RIFF container.</summary>
         wav,
+        /// <summary>FLAC (Free Lossless Audio Codec). Lossless audio compression.</summary>
         flac,
+        /// <summary>MP3 (MPEG Audio Layer III). Lossy audio compression.</summary>
         mp3,
+        /// <summary>Vorbis. Lossy audio compression typically stored in an
+        /// Ogg container.</summary>
         vorbis
     }
 
+    /// <summary>
+    /// Execution paths for the data converter. Determines the sequence of conversion
+    /// steps (format, channel, and resampling) applied to audio data. The converter
+    /// selects the optimal path automatically based on the input and output configurations.
+    /// </summary>
     public enum ma_data_converter_execution_path
     {
+        /// <summary>No conversion needed. Input and output formats, channels, and
+        /// sample rates are identical.</summary>
         passthrough,       /* No conversion. */
+        /// <summary>Only format conversion is needed (e.g. s16 to f32).</summary>
         format_only,       /* Only format conversion. */
+        /// <summary>Only channel conversion is needed (e.g. stereo to mono).</summary>
         channels_only,     /* Only channel conversion. */
+        /// <summary>Only resampling is needed (e.g. 44100 Hz to 48000 Hz).</summary>
         resample_only,     /* Only resampling. */
+        /// <summary>All conversion types needed, with resampling performed as the
+        /// first step.</summary>
         resample_first,    /* All conversions, but resample as the first step. */
+        /// <summary>All conversion types needed, with channel conversion performed
+        /// as the first step.</summary>
         channels_first     /* All conversions, but channels as the first step. */
     }
 
+    /// <summary>
+    /// Channel conversion paths used internally by the channel converter. Describes
+    /// the strategy used to convert between input and output channel configurations.
+    /// </summary>
     public enum ma_channel_conversion_path
     {
+        /// <summary>Unknown conversion path.</summary>
         unknown,
+        /// <summary>No conversion needed. Input and output channel maps are identical.</summary>
         passthrough,
+        /// <summary>Converting a multi-channel signal to mono by averaging all channels.</summary>
         mono_out,    /* Converting to mono. */
+        /// <summary>Converting a mono signal to multi-channel output.</summary>
         mono_in,     /* Converting from mono. */
+        /// <summary>Simple channel reordering. Used when all channels are present in both input and output maps but in different positions.</summary>
         shuffle,     /* Simple shuffle. Will use this when all channels are present in both input and output channel maps, but just in a different order. */
+        /// <summary>Conversion using weighted blending. Used when the input and output
+        /// channel maps differ significantly, requiring channel mixing based on weights.</summary>
         weights      /* Blended based on weights. */
     }
 
+    /// <summary>
+    /// Device lifecycle states. Tracks whether a device is initialized, started,
+    /// stopped, or in a transitional state between started and stopped.
+    /// </summary>
     public enum ma_device_state
     {
+        /// <summary>The device has not been initialized. Default state before
+        /// calling an init function.</summary>
         uninitialized = 0,
+        /// <summary>The device has been initialized but is not processing audio. This is the default state after calling a device init function.</summary>
         stopped = 1,  /* The device's default state after initialization. */
+        /// <summary>The device is actively requesting and/or delivering audio data.</summary>
         started = 2,  /* The device is started and is requesting and/or delivering audio data. */
+        /// <summary>The device is in the process of transitioning from stopped to started.</summary>
         starting = 3,  /* Transitioning from a stopped state to started. */
+        /// <summary>The device is in the process of transitioning from started to stopped.</summary>
         stopping = 4   /* Transitioning from a started state to stopped. */
     }
 
+    /// <summary>
+    /// Flags for sound initialization in the engine. Controls how the resource manager
+    /// loads and manages the audio data, plus engine-specific behavior. Can be combined
+    /// with bitwise OR.
+    /// </summary>
     [Flags]
     public enum ma_sound_flags
     {
+        /// <summary>Load the sound as a stream. The sound data will be loaded incrementally
+        /// from disk on a background thread rather than fully loaded into memory. Best for
+        /// long audio files and music. Equivalent to MA_RESOURCE_MANAGER_DATA_SOURCE_FLAG_STREAM.</summary>
         stream = 0x00000001,   /* MA_RESOURCE_MANAGER_DATA_SOURCE_FLAG_STREAM */
+        /// <summary>Decode the sound data before storing in memory. The decoding is done at the
+        /// resource manager level rather than on the mixing thread, resulting in faster mixing
+        /// but higher memory usage. Equivalent to MA_RESOURCE_MANAGER_DATA_SOURCE_FLAG_DECODE.</summary>
         decode = 0x00000002,   /* MA_RESOURCE_MANAGER_DATA_SOURCE_FLAG_DECODE */
+        /// <summary>Load the sound asynchronously. The sound will be loaded on a background
+        /// thread, and initialization will return immediately. Equivalent to
+        /// MA_RESOURCE_MANAGER_DATA_SOURCE_FLAG_ASYNC.</summary>
         asynchronous = 0x00000004,   /* MA_RESOURCE_MANAGER_DATA_SOURCE_FLAG_ASYNC */
+        /// <summary>Wait for initialization of the underlying data source to complete before
+        /// returning from the init function. When combined with <c>asynchronous</c>, the init
+        /// function blocks until the first data is available. Equivalent to
+        /// MA_RESOURCE_MANAGER_DATA_SOURCE_FLAG_WAIT_INIT.</summary>
         wait_init = 0x00000008,   /* MA_RESOURCE_MANAGER_DATA_SOURCE_FLAG_WAIT_INIT */
+        /// <summary>Hint that the length of the data source is unknown. Avoids calling
+        /// ma_data_source_get_length_in_pcm_frames(). Useful for internet radio streams.
+        /// Equivalent to MA_RESOURCE_MANAGER_DATA_SOURCE_FLAG_UNKNOWN_LENGTH.</summary>
         unknown_length = 0x00000010,   /* MA_RESOURCE_MANAGER_DATA_SOURCE_FLAG_UNKNOWN_LENGTH */
+        /// <summary>Configure the sound to loop by default. Equivalent to
+        /// MA_RESOURCE_MANAGER_DATA_SOURCE_FLAG_LOOPING.</summary>
         looping = 0x00000020,   /* MA_RESOURCE_MANAGER_DATA_SOURCE_FLAG_LOOPING */
 
+        /// <summary>Do not attach the sound to the engine's endpoint by default. Useful
+        /// when setting up nodes in a complex graph system where manual routing is required.</summary>
         /* ma_sound specific flags. */
         no_default_attachment = 0x00001000,   /* Do not attach to the endpoint by default. Useful for when setting up nodes in a complex graph system. */
+        /// <summary>Disable pitch shifting. Pitching functions will have no effect.
+        /// This is an optimization that allows the resampler to be bypassed.</summary>
         no_pitch = 0x00002000,   /* Disable pitch shifting with ma_sound_set_pitch() and ma_sound_group_set_pitch(). This is an optimization. */
+        /// <summary>Disable 3D spatialization. The sound will not be positioned in 3D space
+        /// and will play as a regular stereo/mono source. This is an optimization.</summary>
         no_spatialization = 0x00004000    /* Disable spatialization. */
     }
 
+    /// <summary>
+    /// Playback states for nodes in the audio node graph. A node can be either
+    /// started (actively processing) or stopped (silent).
+    /// </summary>
     public enum ma_node_state
     {
+        /// <summary>The node is started and actively processing audio data.</summary>
         started = 0,
+        /// <summary>The node is stopped and will not process audio data.
+        /// Data is not read from its input connections when stopped.</summary>
         stopped = 1
     }
 
+    /// <summary>
+    /// Flags describing behavioral characteristics of nodes in the audio node graph.
+    /// Can be combined with bitwise OR.
+    /// </summary>
     [Flags]
     public enum ma_node_flags
     {
+        /// <summary>Passthrough mode. Input audio data passes through the node
+        /// without any processing.</summary>
         passthrough = 0x00000001,
+        /// <summary>Continuous processing mode. The node's processing callback will
+        /// be called continuously even when no input data is available, allowing
+        /// the node to generate output from its internal state (e.g. oscillators).</summary>
         continuous_processing = 0x00000002,
+        /// <summary>Allow null input. The node's processing callback will be invoked
+        /// even when no input connections are attached, with null input buffers.</summary>
         allow_null_input = 0x00000004,
+        /// <summary>Enable different processing rates. The node may consume input
+        /// frames and produce output frames at different rates, such as when
+        /// performing resampling internally.</summary>
         different_processing_rates = 0x00000008,
+        /// <summary>Silent output hint. The node's output is expected to be silence
+        /// and downstream processing may be optimized accordingly.</summary>
         silent_output = 0x00000010
     }
 
+    /// <summary>
+    /// Waveform types for the waveform generator. Produces periodic audio signals
+    /// with configurable amplitude and frequency.
+    /// </summary>
     public enum ma_waveform_type
     {
+        /// <summary>Sine wave. Produces a smooth, pure tone with no harmonics.</summary>
         sine,
+        /// <summary>Square wave. Produces a hollow, bright tone with odd harmonics.
+        /// Amplitude alternates between positive and negative at the given frequency.</summary>
         square,
+        /// <summary>Triangle wave. Produces a softer tone than a square wave with
+        /// odd harmonics that roll off more quickly.</summary>
         triangle,
+        /// <summary>Sawtooth wave. Produces a bright, buzzy tone containing both
+        /// even and odd harmonics. The waveform ramps upward and jumps downward.</summary>
         sawtooth
     }
 
+    /// <summary>
+    /// Noise types for the noise generator. Each type has a different frequency
+    /// spectrum characteristic.
+    /// </summary>
     public enum ma_noise_type
     {
+        /// <summary>White noise. Equal energy per frequency across the entire
+        /// spectrum. Sounds like static or hiss.</summary>
         white,
+        /// <summary>Pink noise. Equal energy per octave, with power decreasing
+        /// by 3 dB per octave. Sounds more natural than white noise.</summary>
         pink,
+        /// <summary>Brownian noise (brown noise). Power decreases by 6 dB per octave.
+        /// Sounds deeper and more muffled than pink noise, like a low rumble.</summary>
         brownian
     }
 
+    /// <summary>
+    /// Engine node types for the high-level audio engine. Distinguishes between
+    /// individual sound nodes and sound group nodes for collective control.
+    /// </summary>
     public enum ma_engine_node_type
     {
+        /// <summary>A sound node representing an individual audio source that
+        /// can be positioned, pitched, and faded independently.</summary>
         ma_engine_node_type_sound,
+        /// <summary>A sound group node that can contain multiple children
+        /// (sounds or sub-groups) for collective control of volume, pitch,
+        /// and spatialization.</summary>
         ma_engine_node_type_group
     }
 }

--- a/src/Native/MiniAudioNativePointers.cs
+++ b/src/Native/MiniAudioNativePointers.cs
@@ -53,29 +53,58 @@ using System.Runtime.InteropServices;
 namespace MiniAudioEx.Native
 {
     // ma_pointer_types
+    /// <summary>
+    /// A pointer wrapper for the native <see cref="MiniAudioEx.ma_uint32"/> type.
+    /// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public unsafe struct ma_uint32_ptr
     {
+        /// <summary>
+        /// A pointer to the unmanaged memory for this type.
+        /// </summary>
         public IntPtr pointer;
+        /// <summary>
+        /// Creates an uninitialized pointer wrapper.
+        /// </summary>
         public ma_uint32_ptr() { }
+        /// <summary>
+        /// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+        /// </summary>
+        /// <param name="handle">The native pointer handle to wrap.</param>
         public ma_uint32_ptr(IntPtr handle)
         {
             pointer = handle;
         }
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_uint32_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+        /// <summary>
+        /// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+        /// </summary>
+        /// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
         public ma_uint32_ptr(bool allocate)
         {
             if (allocate)
                 Allocate();
         }
+        /// <summary>
+        /// Allocates unmanaged memory via <see cref="MiniAudioNative.ma_allocate"/> with size <c>Marshal.SizeOf&lt;UInt32&gt;()</c>.
+        /// </summary>
+        /// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
         public bool Allocate()
         {
             pointer = MiniAudioNative.ma_allocate(Marshal.SizeOf<UInt32>());
             return pointer != IntPtr.Zero;
         }
+        /// <summary>
+        /// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+        /// </summary>
         public void Free()
         {
             if (pointer != IntPtr.Zero)
@@ -84,6 +113,10 @@ namespace MiniAudioEx.Native
                 pointer = IntPtr.Zero;
             }
         }
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_uint32"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_uint32*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public UInt32* Get()
 		{
@@ -91,29 +124,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+    /// <summary>
+    /// A pointer wrapper for the native <see cref="MiniAudioEx.ma_async_notification"/> type.
+    /// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_async_notification_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_async_notification_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_async_notification_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_async_notification_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_async_notification_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.async_notification);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -124,29 +186,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_biquad_coefficient"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_biquad_coefficient_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_biquad_coefficient_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_biquad_coefficient_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_biquad_coefficient_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_biquad_coefficient_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.biquad_coefficient);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -155,6 +246,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_biquad_coefficient"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_biquad_coefficient*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_biquad_coefficient* Get()
 		{
@@ -162,29 +257,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_channel"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_channel_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_channel_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_channel_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_channel_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_channel_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.channel);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -195,29 +319,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+    /// <summary>
+    /// A pointer wrapper for the native <see cref="MiniAudioEx.ma_context"/> type.
+    /// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public unsafe struct ma_context_ptr
     {
+        /// <summary>
+        /// A pointer to the unmanaged memory for this type.
+        /// </summary>
         public IntPtr pointer;
+        /// <summary>
+        /// Creates an uninitialized pointer wrapper.
+        /// </summary>
         public ma_context_ptr() { }
+        /// <summary>
+        /// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+        /// </summary>
+        /// <param name="handle">The native pointer handle to wrap.</param>
         public ma_context_ptr(IntPtr handle)
         {
             pointer = handle;
         }
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_context_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+        /// <summary>
+        /// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+        /// </summary>
+        /// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
         public ma_context_ptr(bool allocate)
         {
             if (allocate)
                 Allocate();
         }
+        /// <summary>
+        /// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+        /// </summary>
+        /// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
         public bool Allocate()
         {
             pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.context);
             return pointer != IntPtr.Zero;
         }
+        /// <summary>
+        /// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+        /// </summary>
         public void Free()
         {
             if (pointer != IntPtr.Zero)
@@ -226,6 +379,10 @@ namespace MiniAudioEx.Native
                 pointer = IntPtr.Zero;
             }
         }
+        /// <summary>
+        /// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_context"/> data.
+        /// </summary>
+        /// <returns>A <c>ma_context*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_context* Get()
         {
@@ -233,29 +390,58 @@ namespace MiniAudioEx.Native
         }
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_data_source"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_data_source_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_data_source_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_data_source_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_data_source_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_data_source_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.data_source);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -266,29 +452,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+    /// <summary>
+    /// A pointer wrapper for the native <see cref="MiniAudioEx.ma_data_source_node"/> type.
+    /// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public unsafe struct ma_data_source_node_ptr
     {
+        /// <summary>
+        /// A pointer to the unmanaged memory for this type.
+        /// </summary>
         public IntPtr pointer;
+        /// <summary>
+        /// Creates an uninitialized pointer wrapper.
+        /// </summary>
         public ma_data_source_node_ptr() { }
+        /// <summary>
+        /// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+        /// </summary>
+        /// <param name="handle">The native pointer handle to wrap.</param>
         public ma_data_source_node_ptr(IntPtr handle)
         {
             pointer = handle;
         }
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_data_source_node_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+        /// <summary>
+        /// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+        /// </summary>
+        /// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
         public ma_data_source_node_ptr(bool allocate)
         {
             if (allocate)
                 Allocate();
         }
+        /// <summary>
+        /// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+        /// </summary>
+        /// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
         public bool Allocate()
         {
             pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.data_source_node);
             return pointer != IntPtr.Zero;
         }
+        /// <summary>
+        /// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+        /// </summary>
         public void Free()
         {
             if (pointer != IntPtr.Zero)
@@ -297,6 +512,10 @@ namespace MiniAudioEx.Native
                 pointer = IntPtr.Zero;
             }
         }
+        /// <summary>
+        /// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_data_source_node"/> data.
+        /// </summary>
+        /// <returns>A <c>ma_data_source_node*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_data_source_node* Get()
         {
@@ -304,29 +523,58 @@ namespace MiniAudioEx.Native
         }
 	}
 
+    /// <summary>
+    /// A pointer wrapper for the native <see cref="MiniAudioEx.ma_data_source_vtable"/> type.
+    /// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public unsafe struct ma_data_source_vtable_ptr
     {
+        /// <summary>
+        /// A pointer to the unmanaged memory for this type.
+        /// </summary>
         public IntPtr pointer;
+        /// <summary>
+        /// Creates an uninitialized pointer wrapper.
+        /// </summary>
         public ma_data_source_vtable_ptr() { }
+        /// <summary>
+        /// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+        /// </summary>
+        /// <param name="handle">The native pointer handle to wrap.</param>
         public ma_data_source_vtable_ptr(IntPtr handle)
         {
             pointer = handle;
         }
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_data_source_vtable_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+        /// <summary>
+        /// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+        /// </summary>
+        /// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
         public ma_data_source_vtable_ptr(bool allocate)
         {
             if (allocate)
                 Allocate();
         }
+        /// <summary>
+        /// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+        /// </summary>
+        /// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
         public bool Allocate()
         {
             pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.data_source_vtable);
             return pointer != IntPtr.Zero;
         }
+        /// <summary>
+        /// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+        /// </summary>
         public void Free()
         {
             if (pointer != IntPtr.Zero)
@@ -335,6 +583,10 @@ namespace MiniAudioEx.Native
                 pointer = IntPtr.Zero;
             }
         }
+        /// <summary>
+        /// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_data_source_vtable"/> data.
+        /// </summary>
+        /// <returns>A <c>ma_data_source_vtable*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_data_source_vtable* Get()
         {
@@ -342,29 +594,58 @@ namespace MiniAudioEx.Native
         }
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_decoder"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_decoder_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_decoder_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_decoder_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_decoder_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_decoder_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.decoder);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -373,6 +654,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_decoder"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_decoder*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_decoder* Get()
 		{
@@ -380,29 +665,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+    /// <summary>
+    /// A pointer wrapper for the native <see cref="MiniAudioEx.ma_decoding_backend_vtable"/> type.
+    /// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_decoding_backend_vtable_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_decoding_backend_vtable_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_decoding_backend_vtable_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_decoding_backend_vtable_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_decoding_backend_vtable_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.decoding_backend_vtable);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -411,6 +725,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_decoding_backend_vtable"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_decoding_backend_vtable*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_decoding_backend_vtable* Get()
 		{
@@ -418,29 +736,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+    /// <summary>
+    /// A pointer wrapper for the native <see cref="MiniAudioEx.ma_encoder"/> type.
+    /// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public unsafe struct ma_encoder_ptr
     {
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_encoder_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_encoder_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_encoder_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_encoder_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.encoder);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -449,6 +796,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_encoder"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_encoder*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_encoder* Get()
 		{
@@ -456,29 +807,58 @@ namespace MiniAudioEx.Native
 		}
     }
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_device_resampling"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_device_resampling_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_device_resampling_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_device_resampling_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_device_resampling_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_device_resampling_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.device_resampling);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -487,6 +867,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_device_resampling"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_device_resampling*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_device_resampling* Get()
 		{
@@ -494,29 +878,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_device_playback"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_device_playback_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_device_playback_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_device_playback_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_device_playback_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_device_playback_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.device_playback);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -525,6 +938,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_device_playback"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_device_playback*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_device_playback* Get()
 		{
@@ -532,29 +949,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_device_capture"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_device_capture_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_device_capture_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_device_capture_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_device_capture_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_device_capture_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.device_capture);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -563,6 +1009,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_device_capture"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_device_capture*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_device_capture* Get()
 		{
@@ -570,29 +1020,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_device"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_device_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_device_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_device_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_device_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_device_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.device);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -601,6 +1080,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_device"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_device*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_device* Get()
 		{
@@ -608,29 +1091,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_device_id"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_device_id_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_device_id_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_device_id_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_device_id_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_device_id_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.device_id);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -639,6 +1151,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_device_id"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_device_id*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_device_id* Get()
 		{
@@ -646,29 +1162,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+    /// <summary>
+    /// A pointer wrapper for the native <see cref="MiniAudioEx.ma_device_notification"/> type.
+    /// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public unsafe struct ma_device_notification_ptr
     {
+        /// <summary>
+        /// A pointer to the unmanaged memory for this type.
+        /// </summary>
         public IntPtr pointer;
+        /// <summary>
+        /// Creates an uninitialized pointer wrapper.
+        /// </summary>
         public ma_device_notification_ptr() { }
+        /// <summary>
+        /// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+        /// </summary>
+        /// <param name="handle">The native pointer handle to wrap.</param>
         public ma_device_notification_ptr(IntPtr handle)
         {
             pointer = handle;
         }
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_device_notification_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+        /// <summary>
+        /// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+        /// </summary>
+        /// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
         public ma_device_notification_ptr(bool allocate)
         {
             if (allocate)
                 Allocate();
         }
+        /// <summary>
+        /// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+        /// </summary>
+        /// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
         public bool Allocate()
         {
             pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.device_notification);
             return pointer != IntPtr.Zero;
         }
+        /// <summary>
+        /// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+        /// </summary>
         public void Free()
         {
             if (pointer != IntPtr.Zero)
@@ -679,29 +1224,58 @@ namespace MiniAudioEx.Native
         }
 	}
 
+    /// <summary>
+    /// A pointer wrapper for the native <see cref="MiniAudioEx.ma_device_descriptor"/> type.
+    /// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public unsafe struct ma_device_descriptor_ptr
     {
+        /// <summary>
+        /// A pointer to the unmanaged memory for this type.
+        /// </summary>
         public IntPtr pointer;
+        /// <summary>
+        /// Creates an uninitialized pointer wrapper.
+        /// </summary>
         public ma_device_descriptor_ptr() { }
+        /// <summary>
+        /// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+        /// </summary>
+        /// <param name="handle">The native pointer handle to wrap.</param>
         public ma_device_descriptor_ptr(IntPtr handle)
         {
             pointer = handle;
         }
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_device_descriptor_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+        /// <summary>
+        /// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+        /// </summary>
+        /// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
         public ma_device_descriptor_ptr(bool allocate)
         {
             if (allocate)
                 Allocate();
         }
+        /// <summary>
+        /// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+        /// </summary>
+        /// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
         public bool Allocate()
         {
             pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.device_descriptor);
             return pointer != IntPtr.Zero;
         }
+        /// <summary>
+        /// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+        /// </summary>
         public void Free()
         {
             if (pointer != IntPtr.Zero)
@@ -710,6 +1284,10 @@ namespace MiniAudioEx.Native
                 pointer = IntPtr.Zero;
             }
         }
+        /// <summary>
+        /// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_device_descriptor"/> data.
+        /// </summary>
+        /// <returns>A <c>ma_device_descriptor*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_device_descriptor* Get()
         {
@@ -717,29 +1295,58 @@ namespace MiniAudioEx.Native
         }
 	}
 
+    /// <summary>
+    /// A pointer wrapper for the native <see cref="MiniAudioEx.ma_device_info"/> type.
+    /// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_device_info_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_device_info_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_device_info_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_device_info_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_device_info_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.device_info);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -748,6 +1355,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+        /// <summary>
+        /// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_device_info"/> data.
+        /// </summary>
+        /// <returns>A <c>ma_device_info*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_device_info* Get()
         {
@@ -755,29 +1366,58 @@ namespace MiniAudioEx.Native
         }
 	}
 
+    /// <summary>
+    /// A pointer wrapper for the native <see cref="MiniAudioEx.ma_effect_node"/> type.
+    /// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public unsafe struct ma_effect_node_ptr
     {
+        /// <summary>
+        /// A pointer to the unmanaged memory for this type.
+        /// </summary>
         public IntPtr pointer;
+        /// <summary>
+        /// Creates an uninitialized pointer wrapper.
+        /// </summary>
         public ma_effect_node_ptr() { }
+        /// <summary>
+        /// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+        /// </summary>
+        /// <param name="handle">The native pointer handle to wrap.</param>
         public ma_effect_node_ptr(IntPtr handle)
         {
             pointer = handle;
         }
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_effect_node_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+        /// <summary>
+        /// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+        /// </summary>
+        /// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
         public ma_effect_node_ptr(bool allocate)
         {
             if (allocate)
                 Allocate();
         }
+        /// <summary>
+        /// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+        /// </summary>
+        /// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
         public bool Allocate()
         {
             pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.effect_node);
             return pointer != IntPtr.Zero;
         }
+        /// <summary>
+        /// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+        /// </summary>
         public void Free()
         {
             if (pointer != IntPtr.Zero)
@@ -786,6 +1426,10 @@ namespace MiniAudioEx.Native
                 pointer = IntPtr.Zero;
             }
         }
+        /// <summary>
+        /// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_effect_node"/> data.
+        /// </summary>
+        /// <returns>A <c>ma_effect_node*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_effect_node* Get()
         {
@@ -793,29 +1437,58 @@ namespace MiniAudioEx.Native
         }
 	}
 
+    /// <summary>
+    /// A pointer wrapper for the native <see cref="MiniAudioEx.ma_engine"/> type.
+    /// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public unsafe struct ma_engine_ptr
     {
+        /// <summary>
+        /// A pointer to the unmanaged memory for this type.
+        /// </summary>
         public IntPtr pointer;
+        /// <summary>
+        /// Creates an uninitialized pointer wrapper.
+        /// </summary>
         public ma_engine_ptr() { }
+        /// <summary>
+        /// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+        /// </summary>
+        /// <param name="handle">The native pointer handle to wrap.</param>
         public ma_engine_ptr(IntPtr handle)
         {
             pointer = handle;
         }
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_engine_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+        /// <summary>
+        /// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+        /// </summary>
+        /// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
         public ma_engine_ptr(bool allocate)
         {
             if (allocate)
                 Allocate();
         }
+        /// <summary>
+        /// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+        /// </summary>
+        /// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
         public bool Allocate()
         {
             pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.engine);
             return pointer != IntPtr.Zero;
         }
+        /// <summary>
+        /// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+        /// </summary>
         public void Free()
         {
             if (pointer != IntPtr.Zero)
@@ -824,6 +1497,10 @@ namespace MiniAudioEx.Native
                 pointer = IntPtr.Zero;
             }
         }
+        /// <summary>
+        /// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_engine"/> data.
+        /// </summary>
+        /// <returns>A <c>ma_engine*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_engine* Get()
         {
@@ -831,29 +1508,58 @@ namespace MiniAudioEx.Native
         }
 	}
 
+    /// <summary>
+    /// A pointer wrapper for the native <see cref="MiniAudioEx.ma_fader"/> type.
+    /// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public unsafe struct ma_fader_ptr
     {
+        /// <summary>
+        /// A pointer to the unmanaged memory for this type.
+        /// </summary>
         public IntPtr pointer;
+        /// <summary>
+        /// Creates an uninitialized pointer wrapper.
+        /// </summary>
         public ma_fader_ptr() { }
+        /// <summary>
+        /// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+        /// </summary>
+        /// <param name="handle">The native pointer handle to wrap.</param>
         public ma_fader_ptr(IntPtr handle)
         {
             pointer = handle;
         }
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_fader_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+        /// <summary>
+        /// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+        /// </summary>
+        /// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
         public ma_fader_ptr(bool allocate)
         {
             if (allocate)
                 Allocate();
         }
+        /// <summary>
+        /// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+        /// </summary>
+        /// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
         public bool Allocate()
         {
             pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.fader);
             return pointer != IntPtr.Zero;
         }
+        /// <summary>
+        /// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+        /// </summary>
         public void Free()
         {
             if (pointer != IntPtr.Zero)
@@ -862,6 +1568,10 @@ namespace MiniAudioEx.Native
                 pointer = IntPtr.Zero;
             }
         }
+        /// <summary>
+        /// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_fader"/> data.
+        /// </summary>
+        /// <returns>A <c>ma_fader*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_fader* Get()
         {
@@ -869,29 +1579,58 @@ namespace MiniAudioEx.Native
         }
 	}
 
+    /// <summary>
+    /// A pointer wrapper for the native <see cref="MiniAudioEx.ma_fence"/> type.
+    /// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_fence_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_fence_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_fence_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_fence_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_fence_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.fence);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -902,29 +1641,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+    /// <summary>
+    /// A pointer wrapper for the native <see cref="MiniAudioEx.ma_gainer"/> type.
+    /// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public unsafe struct ma_gainer_ptr
     {
+        /// <summary>
+        /// A pointer to the unmanaged memory for this type.
+        /// </summary>
         public IntPtr pointer;
+        /// <summary>
+        /// Creates an uninitialized pointer wrapper.
+        /// </summary>
         public ma_gainer_ptr() { }
+        /// <summary>
+        /// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+        /// </summary>
+        /// <param name="handle">The native pointer handle to wrap.</param>
         public ma_gainer_ptr(IntPtr handle)
         {
             pointer = handle;
         }
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_gainer_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+        /// <summary>
+        /// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+        /// </summary>
+        /// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
         public ma_gainer_ptr(bool allocate)
         {
             if (allocate)
                 Allocate();
         }
+        /// <summary>
+        /// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+        /// </summary>
+        /// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
         public bool Allocate()
         {
             pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.gainer);
             return pointer != IntPtr.Zero;
         }
+        /// <summary>
+        /// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+        /// </summary>
         public void Free()
         {
             if (pointer != IntPtr.Zero)
@@ -933,6 +1701,10 @@ namespace MiniAudioEx.Native
                 pointer = IntPtr.Zero;
             }
         }
+        /// <summary>
+        /// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_gainer"/> data.
+        /// </summary>
+        /// <returns>A <c>ma_gainer*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_gainer* Get()
         {
@@ -940,29 +1712,58 @@ namespace MiniAudioEx.Native
         }
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_log"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_log_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_log_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_log_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_log_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_log_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.log);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -971,6 +1772,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+        /// <summary>
+        /// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_log"/> data.
+        /// </summary>
+        /// <returns>A <c>ma_log*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_log* Get()
         {
@@ -978,29 +1783,58 @@ namespace MiniAudioEx.Native
         }
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_lpf"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_lpf_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_lpf_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_lpf_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_lpf_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_lpf_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.lpf);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -1009,6 +1843,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_lpf"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_lpf*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_lpf* Get()
 		{
@@ -1016,29 +1854,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_lpf1"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_lpf1_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_lpf1_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_lpf1_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_lpf1_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_lpf1_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.lpf1);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -1047,6 +1914,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_lpf1"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_lpf1*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_lpf1* Get()
 		{
@@ -1054,29 +1925,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_lpf2"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_lpf2_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_lpf2_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_lpf2_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_lpf2_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_lpf2_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.lpf2);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -1085,6 +1985,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_lpf2"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_lpf2*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_lpf2* Get()
 		{
@@ -1092,29 +1996,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_hpf"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_hpf_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_hpf_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_hpf_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_hpf_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_hpf_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.hpf);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -1123,6 +2056,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_hpf"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_hpf*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_hpf* Get()
 		{
@@ -1130,29 +2067,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_hpf1"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_hpf1_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_hpf1_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_hpf1_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_hpf1_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_hpf1_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.hpf1);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -1161,6 +2127,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_hpf1"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_hpf1*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_hpf1* Get()
 		{
@@ -1168,29 +2138,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_hpf2"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_hpf2_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_hpf2_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_hpf2_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_hpf2_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_hpf2_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.hpf2);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -1199,6 +2198,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_hpf2"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_hpf2*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_hpf2* Get()
 		{
@@ -1206,29 +2209,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_bpf"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_bpf_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_bpf_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_bpf_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_bpf_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_bpf_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.bpf);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -1237,6 +2269,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_bpf"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_bpf*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_bpf* Get()
 		{
@@ -1244,29 +2280,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_bpf2"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_bpf2_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_bpf2_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_bpf2_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_bpf2_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_bpf2_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.bpf2);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -1275,6 +2340,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_bpf2"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_bpf2*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_bpf2* Get()
 		{
@@ -1282,29 +2351,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_biquad"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_biquad_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_biquad_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_biquad_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_biquad_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_biquad_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.biquad);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -1313,6 +2411,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_biquad"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_biquad*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_biquad* Get()
 		{
@@ -1320,29 +2422,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_notch2"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_notch2_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_notch2_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_notch2_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_notch2_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_notch2_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.notch2);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -1351,6 +2482,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_notch2"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_notch2*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_notch2* Get()
 		{
@@ -1358,29 +2493,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_peak2"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_peak2_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_peak2_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_peak2_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_peak2_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_peak2_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.peak2);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -1389,6 +2553,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_peak2"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_peak2*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_peak2* Get()
 		{
@@ -1396,29 +2564,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_loshelf2"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_loshelf2_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_loshelf2_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_loshelf2_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_loshelf2_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_loshelf2_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.loshelf2);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -1427,6 +2624,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_loshelf2"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_loshelf2*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_loshelf2* Get()
 		{
@@ -1434,29 +2635,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_hishelf2"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_hishelf2_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_hishelf2_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_hishelf2_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_hishelf2_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_hishelf2_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.hishelf2);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -1465,6 +2695,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_hishelf2"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_hishelf2*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_hishelf2* Get()
 		{
@@ -1472,29 +2706,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_lpf_node"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_lpf_node_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_lpf_node_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_lpf_node_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_lpf_node_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_lpf_node_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.lpf_node);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -1503,6 +2766,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_lpf_node"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_lpf_node*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_lpf_node* Get()
 		{
@@ -1510,29 +2777,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+    /// <summary>
+    /// A pointer wrapper for the native <see cref="MiniAudioEx.ma_hpf_node"/> type.
+    /// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_hpf_node_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_hpf_node_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_hpf_node_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_hpf_node_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_hpf_node_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.hpf_node);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -1541,6 +2837,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_hpf_node"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_hpf_node*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_hpf_node* Get()
 		{
@@ -1548,29 +2848,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+    /// <summary>
+    /// A pointer wrapper for the native <see cref="MiniAudioEx.ma_bpf_node"/> type.
+    /// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_bpf_node_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_bpf_node_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_bpf_node_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_bpf_node_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_bpf_node_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.bpf_node);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -1579,6 +2908,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_bpf_node"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_bpf_node*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_bpf_node* Get()
 		{
@@ -1586,29 +2919,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+    /// <summary>
+    /// A pointer wrapper for the native <see cref="MiniAudioEx.ma_notch_node"/> type.
+    /// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_notch_node_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_notch_node_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_notch_node_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_notch_node_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_notch_node_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.notch_node);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -1617,6 +2979,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_notch_node"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_notch_node*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_notch_node* Get()
 		{
@@ -1624,29 +2990,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+    /// <summary>
+    /// A pointer wrapper for the native <see cref="MiniAudioEx.ma_peak_node"/> type.
+    /// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_peak_node_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_peak_node_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_peak_node_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_peak_node_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_peak_node_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.peak_node);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -1655,6 +3050,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_peak_node"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_peak_node*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_peak_node* Get()
 		{
@@ -1662,29 +3061,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+    /// <summary>
+    /// A pointer wrapper for the native <see cref="MiniAudioEx.ma_loshelf_node"/> type.
+    /// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_loshelf_node_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_loshelf_node_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_loshelf_node_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_loshelf_node_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_loshelf_node_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.loshelf_node);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -1693,6 +3121,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_loshelf_node"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_loshelf_node*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_loshelf_node* Get()
 		{
@@ -1700,29 +3132,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+    /// <summary>
+    /// A pointer wrapper for the native <see cref="MiniAudioEx.ma_hishelf_node"/> type.
+    /// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_hishelf_node_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_hishelf_node_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_hishelf_node_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_hishelf_node_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_hishelf_node_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.hishelf_node);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -1731,6 +3192,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_hishelf_node"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_hishelf_node*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_hishelf_node* Get()
 		{
@@ -1738,29 +3203,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_delay"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_delay_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_delay_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_delay_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_delay_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_delay_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.delay);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -1769,6 +3263,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_delay"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_delay*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_delay* Get()
 		{
@@ -1776,29 +3274,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_delay_node"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_delay_node_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_delay_node_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_delay_node_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_delay_node_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_delay_node_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.delay_node);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -1807,6 +3334,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_delay_node"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_delay_node*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_delay_node* Get()
 		{
@@ -1814,29 +3345,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_splitter_node"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_splitter_node_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_splitter_node_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_splitter_node_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_splitter_node_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_splitter_node_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.splitter_node);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -1845,6 +3405,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_splitter_node"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_splitter_node*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_splitter_node* Get()
 		{
@@ -1852,29 +3416,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_node"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_node_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_node_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_node_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_node_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_node_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.node);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -1885,29 +3478,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_node_base"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_node_base_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_node_base_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_node_base_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_node_base_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_node_base_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.node_base);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -1916,6 +3538,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_node_base"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_node_base*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_node_base* Get()
 		{
@@ -1923,29 +3549,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_node_graph"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_node_graph_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_node_graph_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_node_graph_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_node_graph_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_node_graph_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.node_graph);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -1954,6 +3609,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_node_graph"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_node_graph*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_node_graph* Get()
 		{
@@ -1961,29 +3620,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_node_input_bus"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_node_input_bus_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_node_input_bus_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_node_input_bus_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_node_input_bus_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_node_input_bus_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.node_input_bus);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -1992,6 +3680,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_node_input_bus"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_node_input_bus*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_node_input_bus* Get()
 		{
@@ -1999,29 +3691,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_node_output_bus"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_node_output_bus_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_node_output_bus_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_node_output_bus_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_node_output_bus_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_node_output_bus_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.node_output_bus);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -2030,6 +3751,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_node_output_bus"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_node_output_bus*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_node_output_bus* Get()
 		{
@@ -2037,29 +3762,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_node_vtable"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_node_vtable_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_node_vtable_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_node_vtable_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_node_vtable_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_node_vtable_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.node_vtable);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -2068,6 +3822,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_node_vtable"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_node_vtable*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_node_vtable* Get()
 		{
@@ -2075,29 +3833,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_panner"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_panner_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_panner_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_panner_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_panner_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_panner_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.panner);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -2106,6 +3893,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_panner"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_panner*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_panner* Get()
 		{
@@ -2113,29 +3904,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_procedural_data_source"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_procedural_data_source_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_procedural_data_source_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_procedural_data_source_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_procedural_data_source_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_procedural_data_source_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.procedural_data_source);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -2144,6 +3964,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_procedural_data_source"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_procedural_data_source*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_procedural_data_source* Get()
 		{
@@ -2151,29 +3975,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_resampling_backend_vtable"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_resampling_backend_vtable_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_resampling_backend_vtable_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_resampling_backend_vtable_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_resampling_backend_vtable_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_resampling_backend_vtable_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.resampling_backend_vtable);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -2184,29 +4037,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_resource_manager"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_resource_manager_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_resource_manager_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_resource_manager_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_resource_manager_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_resource_manager_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.resource_manager);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -2217,29 +4099,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+    /// <summary>
+    /// A pointer wrapper for the native <see cref="MiniAudioEx.ma_resource_manager_data_source"/> type.
+    /// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_resource_manager_data_source_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_resource_manager_data_source_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_resource_manager_data_source_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_resource_manager_data_source_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_resource_manager_data_source_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.resource_manager_data_source);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -2251,29 +4162,58 @@ namespace MiniAudioEx.Native
 	}
 
 
+    /// <summary>
+    /// A pointer wrapper for the native <see cref="MiniAudioEx.ma_sound"/> type.
+    /// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public unsafe struct ma_sound_ptr
     {
+        /// <summary>
+        /// A pointer to the unmanaged memory for this type.
+        /// </summary>
         public IntPtr pointer;
+        /// <summary>
+        /// Creates an uninitialized pointer wrapper.
+        /// </summary>
         public ma_sound_ptr() { }
+        /// <summary>
+        /// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+        /// </summary>
+        /// <param name="handle">The native pointer handle to wrap.</param>
         public ma_sound_ptr(IntPtr handle)
         {
             pointer = handle;
         }
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_sound_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+        /// <summary>
+        /// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+        /// </summary>
+        /// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
         public ma_sound_ptr(bool allocate)
         {
             if (allocate)
                 Allocate();
         }
+        /// <summary>
+        /// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+        /// </summary>
+        /// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
         public bool Allocate()
         {
             pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.sound);
             return pointer != IntPtr.Zero;
         }
+        /// <summary>
+        /// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+        /// </summary>
         public void Free()
         {
             if (pointer != IntPtr.Zero)
@@ -2282,6 +4222,10 @@ namespace MiniAudioEx.Native
                 pointer = IntPtr.Zero;
             }
         }
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_sound"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_sound*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_sound* Get()
 		{
@@ -2289,29 +4233,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+    /// <summary>
+    /// A pointer wrapper for the native <see cref="MiniAudioEx.ma_sound_inlined"/> type.
+    /// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public unsafe struct ma_sound_inlined_ptr
     {
+        /// <summary>
+        /// A pointer to the unmanaged memory for this type.
+        /// </summary>
         public IntPtr pointer;
+        /// <summary>
+        /// Creates an uninitialized pointer wrapper.
+        /// </summary>
         public ma_sound_inlined_ptr() { }
+        /// <summary>
+        /// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+        /// </summary>
+        /// <param name="handle">The native pointer handle to wrap.</param>
         public ma_sound_inlined_ptr(IntPtr handle)
         {
             pointer = handle;
         }
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_sound_inlined_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+        /// <summary>
+        /// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+        /// </summary>
+        /// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
         public ma_sound_inlined_ptr(bool allocate)
         {
             if (allocate)
                 Allocate();
         }
+        /// <summary>
+        /// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+        /// </summary>
+        /// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
         public bool Allocate()
         {
             pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.sound_inlined);
             return pointer != IntPtr.Zero;
         }
+        /// <summary>
+        /// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+        /// </summary>
         public void Free()
         {
             if (pointer != IntPtr.Zero)
@@ -2320,6 +4293,10 @@ namespace MiniAudioEx.Native
                 pointer = IntPtr.Zero;
             }
         }
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_sound_inlined"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_sound_inlined*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_sound_inlined* Get()
 		{
@@ -2327,30 +4304,59 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+    /// <summary>
+    /// A pointer wrapper for the native <see cref="MiniAudioEx.ma_sound_group"/> type.
+    /// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     // ma_sound_group is an alias for ma_sound
     public unsafe struct ma_sound_group_ptr
     {
+        /// <summary>
+        /// A pointer to the unmanaged memory for this type.
+        /// </summary>
         public IntPtr pointer;
+        /// <summary>
+        /// Creates an uninitialized pointer wrapper.
+        /// </summary>
         public ma_sound_group_ptr() { }
+        /// <summary>
+        /// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+        /// </summary>
+        /// <param name="handle">The native pointer handle to wrap.</param>
         public ma_sound_group_ptr(IntPtr handle)
         {
             pointer = handle;
         }
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_sound_group_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+        /// <summary>
+        /// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+        /// </summary>
+        /// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
         public ma_sound_group_ptr(bool allocate)
         {
             if (allocate)
                 Allocate();
         }
+        /// <summary>
+        /// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+        /// </summary>
+        /// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
         public bool Allocate()
         {
             pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.sound_group);
             return pointer != IntPtr.Zero;
         }
+        /// <summary>
+        /// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+        /// </summary>
         public void Free()
         {
             if (pointer != IntPtr.Zero)
@@ -2359,6 +4365,10 @@ namespace MiniAudioEx.Native
                 pointer = IntPtr.Zero;
             }
         }
+        /// <summary>
+        /// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_sound_group"/> data.
+        /// </summary>
+        /// <returns>A <c>ma_sound_group*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_sound* Get()
         {
@@ -2366,29 +4376,58 @@ namespace MiniAudioEx.Native
         }
     }
 
+    /// <summary>
+    /// A pointer wrapper for the native <see cref="MiniAudioEx.ma_spatializer"/> type.
+    /// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public unsafe struct ma_spatializer_ptr
     {
+        /// <summary>
+        /// A pointer to the unmanaged memory for this type.
+        /// </summary>
         public IntPtr pointer;
+        /// <summary>
+        /// Creates an uninitialized pointer wrapper.
+        /// </summary>
         public ma_spatializer_ptr() { }
+        /// <summary>
+        /// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+        /// </summary>
+        /// <param name="handle">The native pointer handle to wrap.</param>
         public ma_spatializer_ptr(IntPtr handle)
         {
             pointer = handle;
         }
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_spatializer_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+        /// <summary>
+        /// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+        /// </summary>
+        /// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
         public ma_spatializer_ptr(bool allocate)
         {
             if (allocate)
                 Allocate();
         }
+        /// <summary>
+        /// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+        /// </summary>
+        /// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
         public bool Allocate()
         {
             pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.spatializer);
             return pointer != IntPtr.Zero;
         }
+        /// <summary>
+        /// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+        /// </summary>
         public void Free()
         {
             if (pointer != IntPtr.Zero)
@@ -2397,6 +4436,10 @@ namespace MiniAudioEx.Native
                 pointer = IntPtr.Zero;
             }
         }
+        /// <summary>
+        /// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_spatializer"/> data.
+        /// </summary>
+        /// <returns>A <c>ma_spatializer*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_spatializer* Get()
         {
@@ -2404,29 +4447,58 @@ namespace MiniAudioEx.Native
         }
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_spatializer_listener"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_spatializer_listener_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_spatializer_listener_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_spatializer_listener_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_spatializer_listener_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_spatializer_listener_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.spatializer_listener);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -2435,6 +4507,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_spatializer_listener"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_spatializer_listener*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_spatializer_listener* Get()
 		{
@@ -2442,29 +4518,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_stack"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_stack_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_stack_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_stack_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_stack_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_stack_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.stack);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -2473,6 +4578,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_stack"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_stack*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_stack* Get()
 		{
@@ -2480,29 +4589,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_vfs"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
 	public unsafe struct ma_vfs_ptr
 	{
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_vfs_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_vfs_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_vfs_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_vfs_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.vfs);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -2513,29 +4651,58 @@ namespace MiniAudioEx.Native
 		}
 	}
 
+	/// <summary>
+	/// A pointer wrapper for the native <see cref="MiniAudioEx.ma_waveform"/> type.
+	/// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+	/// </summary>
 	[StructLayout(LayoutKind.Sequential)]
     public unsafe struct ma_waveform_ptr
     {
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_waveform_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_waveform_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_waveform_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_waveform_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.waveform);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -2544,6 +4711,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_waveform"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_waveform*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_waveform* Get()
 		{
@@ -2551,29 +4722,58 @@ namespace MiniAudioEx.Native
 		}
     }
 
+    /// <summary>
+    /// A pointer wrapper for the native <see cref="MiniAudioEx.ma_pulsewave"/> type.
+    /// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public unsafe struct ma_pulsewave_ptr
     {
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_pulsewave_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_pulsewave_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_pulsewave_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_pulsewave_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.pulsewave);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -2582,6 +4782,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_pulsewave"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_pulsewave*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_pulsewave* Get()
 		{
@@ -2589,29 +4793,58 @@ namespace MiniAudioEx.Native
 		}
     }
 
+    /// <summary>
+    /// A pointer wrapper for the native <see cref="MiniAudioEx.ma_noise"/> type.
+    /// Provides managed memory allocation and deallocation via miniaudio's allocation API.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public unsafe struct ma_noise_ptr
     {
+		/// <summary>
+		/// A pointer to the unmanaged memory for this type.
+		/// </summary>
 		public IntPtr pointer;
+		/// <summary>
+		/// Creates an uninitialized pointer wrapper.
+		/// </summary>
 		public ma_noise_ptr() { }
+		/// <summary>
+		/// Creates a pointer wrapper from an existing <see cref="IntPtr"/> handle.
+		/// </summary>
+		/// <param name="handle">The native pointer handle to wrap.</param>
 		public ma_noise_ptr(IntPtr handle)
 		{
 			pointer = handle;
 		}
+		/// <summary>
+		/// Creates a pointer wrapper from a native <c>void*</c> pointer.
+		/// </summary>
+		/// <param name="handle">The native void pointer to wrap.</param>
 		public ma_noise_ptr(void* handle)
 		{
 			pointer = new IntPtr(handle);
 		}
+		/// <summary>
+		/// Creates a pointer wrapper and optionally allocates unmanaged memory for the native type.
+		/// </summary>
+		/// <param name="allocate">If <c>true</c>, allocates memory via the miniaudio allocation API.</param>
 		public ma_noise_ptr(bool allocate)
 		{
 			if (allocate)
 				Allocate();
 		}
+		/// <summary>
+		/// Allocates unmanaged memory for the native type via <see cref="MiniAudioNative.ma_allocate_type"/>.
+		/// </summary>
+		/// <returns><c>true</c> if allocation succeeded; otherwise, <c>false</c>.</returns>
 		public bool Allocate()
 		{
 			pointer = MiniAudioNative.ma_allocate_type(ma_allocation_type.noise);
 			return pointer != IntPtr.Zero;
 		}
+		/// <summary>
+		/// Deallocates the unmanaged memory via <see cref="MiniAudioNative.ma_deallocate_type"/> and sets the pointer to <see cref="IntPtr.Zero"/>.
+		/// </summary>
 		public void Free()
 		{
 			if (pointer != IntPtr.Zero)
@@ -2620,6 +4853,10 @@ namespace MiniAudioEx.Native
 				pointer = IntPtr.Zero;
 			}
 		}
+		/// <summary>
+		/// Returns a typed pointer to the underlying <see cref="MiniAudioEx.ma_noise"/> data.
+		/// </summary>
+		/// <returns>A <c>ma_noise*</c> pointer cast from the wrapped <see cref="IntPtr"/>.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ma_noise* Get()
 		{

--- a/src/Native/MiniAudioNativeStructures.cs
+++ b/src/Native/MiniAudioNativeStructures.cs
@@ -67,61 +67,100 @@ namespace MiniAudioEx.Native
     using ma_vfs_file = IntPtr;
     using ma_spinlock = UInt32;
 
+    /// <summary>
+    /// Represents a platform-sized unsigned integer, analogous to <c>size_t</c> in C/C++.
+    /// Provides implicit conversions from and arithmetic operators for <see cref="UIntPtr"/>, <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>, and <see cref="ulong"/>.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct size_t
     {
         private UIntPtr value;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="size_t"/> struct with the specified <see cref="UIntPtr"/> value.
+        /// </summary>
+        /// <param name="value">The unsigned pointer-sized value.</param>
         public size_t(UIntPtr value)
         {
             this.value = value;
         }
 
+        /// <summary>
+        /// Implicitly converts a <see cref="UIntPtr"/> to a <see cref="size_t"/>.
+        /// </summary>
         public static implicit operator size_t(UIntPtr value)
         {
             return new size_t(value);
         }
 
+        /// <summary>
+        /// Implicitly converts a <see cref="size_t"/> to a <see cref="UIntPtr"/>.
+        /// </summary>
         public static implicit operator UIntPtr(size_t size)
         {
             return size.value;
         }
 
+        /// <summary>
+        /// Implicitly converts an <see cref="int"/> to a <see cref="size_t"/>.
+        /// </summary>
         public static implicit operator size_t(int value)
         {
             return new size_t((UIntPtr)(uint)value);
         }
 
+        /// <summary>
+        /// Implicitly converts a <see cref="uint"/> to a <see cref="size_t"/>.
+        /// </summary>
         public static implicit operator size_t(uint value)
         {
             return new size_t((UIntPtr)value);
         }
 
+        /// <summary>
+        /// Implicitly converts a <see cref="long"/> to a <see cref="size_t"/>.
+        /// </summary>
         public static implicit operator size_t(long value)
         {
             return new size_t((UIntPtr)(ulong)value);
         }
 
+        /// <summary>
+        /// Implicitly converts a <see cref="ulong"/> to a <see cref="size_t"/>.
+        /// </summary>
         public static implicit operator size_t(ulong value)
         {
             return new size_t((UIntPtr)value);
         }
 
+        /// <summary>
+        /// Adds two <see cref="size_t"/> values.
+        /// </summary>
         public static size_t operator +(size_t a, size_t b)
         {
             return new size_t((UIntPtr)(a.ToUInt64() + b.ToUInt64()));
         }
 
+        /// <summary>
+        /// Subtracts one <see cref="size_t"/> from another.
+        /// </summary>
         public static size_t operator -(size_t a, size_t b)
         {
             return new size_t((UIntPtr)(a.ToUInt64() - b.ToUInt64()));
         }
 
+        /// <summary>
+        /// Multiplies two <see cref="size_t"/> values.
+        /// </summary>
         public static size_t operator *(size_t a, size_t b)
         {
             return new size_t((UIntPtr)(a.ToUInt64() * b.ToUInt64()));
         }
 
+        /// <summary>
+        /// Divides one <see cref="size_t"/> by another.
+        /// </summary>
+        /// <exception cref="DivideByZeroException">Thrown when <paramref name="b"/> is zero.</exception>
         public static size_t operator /(size_t a, size_t b)
         {
             if (b.value == UIntPtr.Zero)
@@ -129,51 +168,82 @@ namespace MiniAudioEx.Native
             return new size_t((UIntPtr)(a.ToUInt64() / b.ToUInt64()));
         }
 
+        /// <summary>
+        /// Compares two <see cref="size_t"/> values for equality.
+        /// </summary>
         public static bool operator ==(size_t a, size_t b)
         {
             return a.value == b.value;
         }
 
+        /// <summary>
+        /// Compares two <see cref="size_t"/> values for inequality.
+        /// </summary>
         public static bool operator !=(size_t a, size_t b)
         {
             return a.value != b.value;
         }
 
+        /// <summary>
+        /// Determines whether one <see cref="size_t"/> is less than another.
+        /// </summary>
         public static bool operator <(size_t a, size_t b)
         {
             return a.ToUInt64() < b.ToUInt64();
         }
 
+        /// <summary>
+        /// Determines whether one <see cref="size_t"/> is greater than another.
+        /// </summary>
         public static bool operator >(size_t a, size_t b)
         {
             return a.ToUInt64() > b.ToUInt64();
         }
 
+        /// <summary>
+        /// Determines whether one <see cref="size_t"/> is less than or equal to another.
+        /// </summary>
         public static bool operator <=(size_t a, size_t b)
         {
             return a.ToUInt64() <= b.ToUInt64();
         }
 
+        /// <summary>
+        /// Determines whether one <see cref="size_t"/> is greater than or equal to another.
+        /// </summary>
         public static bool operator >=(size_t a, size_t b)
         {
             return a.ToUInt64() >= b.ToUInt64();
         }
 
+        /// <summary>
+        /// Adds a <see cref="ulong"/> to a <see cref="size_t"/>.
+        /// </summary>
         public static size_t operator +(size_t a, ulong b)
         {
             return new size_t((UIntPtr)(a.value.ToUInt64() + b));
         }
 
+        /// <summary>
+        /// Subtracts a <see cref="ulong"/> from a <see cref="size_t"/>.
+        /// </summary>
         public static size_t operator -(size_t a, ulong b)
         {
             return new size_t((UIntPtr)(a.value.ToUInt64() - b));
         }
 
+        /// <summary>
+        /// Multiplies a <see cref="size_t"/> by a <see cref="ulong"/>.
+        /// </summary>
         public static size_t operator *(size_t a, ulong b)
         {
             return new size_t((UIntPtr)(a.ToUInt64() * b));
         }
 
+        /// <summary>
+        /// Divides a <see cref="size_t"/> by a <see cref="ulong"/>.
+        /// </summary>
+        /// <exception cref="DivideByZeroException">Thrown when <paramref name="b"/> is zero.</exception>
         public static size_t operator /(size_t a, ulong b)
         {
             if (b == 0)
@@ -181,21 +251,34 @@ namespace MiniAudioEx.Native
             return new size_t((UIntPtr)(a.ToUInt64() / b));
         }
 
+        /// <summary>
+        /// Adds a <see cref="size_t"/> to a <see cref="ulong"/>.
+        /// </summary>
         public static size_t operator +(ulong a, size_t b)
         {
             return new size_t((UIntPtr)(a + b.ToUInt64()));
         }
 
+        /// <summary>
+        /// Subtracts a <see cref="size_t"/> from a <see cref="ulong"/>.
+        /// </summary>
         public static size_t operator -(ulong a, size_t b)
         {
             return new size_t((UIntPtr)(a - b.ToUInt64()));
         }
 
+        /// <summary>
+        /// Multiplies a <see cref="ulong"/> by a <see cref="size_t"/>.
+        /// </summary>
         public static size_t operator *(ulong a, size_t b)
         {
             return new size_t((UIntPtr)(a * b.ToUInt64()));
         }
 
+        /// <summary>
+        /// Divides a <see cref="ulong"/> by a <see cref="size_t"/>.
+        /// </summary>
+        /// <exception cref="DivideByZeroException">Thrown when <paramref name="b"/> is zero.</exception>
         public static size_t operator /(ulong a, size_t b)
         {
             if (b.value == UIntPtr.Zero)
@@ -203,21 +286,34 @@ namespace MiniAudioEx.Native
             return new size_t((UIntPtr)(a / b.ToUInt64()));
         }
 
+        /// <summary>
+        /// Adds a <see cref="uint"/> to a <see cref="size_t"/>.
+        /// </summary>
         public static size_t operator +(size_t a, uint b)
         {
             return new size_t((UIntPtr)(a.value.ToUInt64() + b));
         }
 
+        /// <summary>
+        /// Subtracts a <see cref="uint"/> from a <see cref="size_t"/>.
+        /// </summary>
         public static size_t operator -(size_t a, uint b)
         {
             return new size_t((UIntPtr)(a.value.ToUInt64() - b));
         }
 
+        /// <summary>
+        /// Multiplies a <see cref="size_t"/> by a <see cref="uint"/>.
+        /// </summary>
         public static size_t operator *(size_t a, uint b)
         {
             return new size_t((UIntPtr)(a.ToUInt64() * b));
         }
 
+        /// <summary>
+        /// Divides a <see cref="size_t"/> by a <see cref="uint"/>.
+        /// </summary>
+        /// <exception cref="DivideByZeroException">Thrown when <paramref name="b"/> is zero.</exception>
         public static size_t operator /(size_t a, uint b)
         {
             if (b == 0)
@@ -225,21 +321,34 @@ namespace MiniAudioEx.Native
             return new size_t((UIntPtr)(a.ToUInt64() / b));
         }
 
+        /// <summary>
+        /// Adds a <see cref="size_t"/> to a <see cref="uint"/>.
+        /// </summary>
         public static size_t operator +(uint a, size_t b)
         {
             return new size_t((UIntPtr)(a + b.ToUInt64()));
         }
 
+        /// <summary>
+        /// Subtracts a <see cref="size_t"/> from a <see cref="uint"/>.
+        /// </summary>
         public static size_t operator -(uint a, size_t b)
         {
             return new size_t((UIntPtr)(a - b.ToUInt64()));
         }
 
+        /// <summary>
+        /// Multiplies a <see cref="uint"/> by a <see cref="size_t"/>.
+        /// </summary>
         public static size_t operator *(uint a, size_t b)
         {
             return new size_t((UIntPtr)(a * b.ToUInt64()));
         }
 
+        /// <summary>
+        /// Divides a <see cref="uint"/> by a <see cref="size_t"/>.
+        /// </summary>
+        /// <exception cref="DivideByZeroException">Thrown when <paramref name="b"/> is zero.</exception>
         public static size_t operator /(uint a, size_t b)
         {
             if (b.value == UIntPtr.Zero)
@@ -247,16 +356,29 @@ namespace MiniAudioEx.Native
             return new size_t((UIntPtr)(a / b.ToUInt64()));
         }
 
+        /// <summary>
+        /// Converts the value to a <see cref="ulong"/>.
+        /// </summary>
+        /// <returns>The value as a <see cref="ulong"/>.</returns>
         public ulong ToUInt64()
         {
             return value.ToUInt64();
         }
 
+        /// <summary>
+        /// Converts the value to a <see cref="uint"/>.
+        /// </summary>
+        /// <returns>The value as a <see cref="uint"/>.</returns>
         public uint ToUInt32()
         {
             return value.ToUInt32();
         }
 
+        /// <summary>
+        /// Indicates whether this instance and a specified object are equal.
+        /// </summary>
+        /// <param name="obj">The object to compare with the current instance.</param>
+        /// <returns><c>true</c> if <paramref name="obj"/> is a <see cref="size_t"/> with the same value; otherwise, <c>false</c>.</returns>
         public override bool Equals(object obj)
         {
             if (obj is size_t)
@@ -266,6 +388,10 @@ namespace MiniAudioEx.Native
             return false;
         }
 
+        /// <summary>
+        /// Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
             return value.GetHashCode();
@@ -273,51 +399,126 @@ namespace MiniAudioEx.Native
     }
 
     // ma_structures
+    /// <summary>
+    /// Custom memory allocation callbacks. Allows the application to override the default memory
+    /// allocation routines used by miniaudio. Each callback receives the user data pointer as a parameter.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_allocation_callbacks
     {
+        /// <summary>
+        /// A pointer to user data that is passed to each allocation callback.
+        /// </summary>
         public IntPtr pUserData;
+        /// <summary>
+        /// A pointer to the custom allocation function (<c>void* (*)(size_t, void*)</c>).
+        /// </summary>
         public IntPtr onMalloc;
+        /// <summary>
+        /// A pointer to the custom reallocation function (<c>void* (*)(void*, size_t, void*)</c>).
+        /// </summary>
         public IntPtr onRealloc;
+        /// <summary>
+        /// A pointer to the custom free function (<c>void (*)(void*, void*)</c>).
+        /// </summary>
         public IntPtr onFree;
 
+        /// <summary>
+        /// Sets the custom memory allocation callback.
+        /// </summary>
+        /// <param name="callback">The delegate of type <see cref="ma_allocation_callbacks_malloc_proc"/>.</param>
         public void SetMallocProc(ma_allocation_callbacks_malloc_proc callback)
         {
             onMalloc = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
 
+        /// <summary>
+        /// Sets the custom memory reallocation callback.
+        /// </summary>
+        /// <param name="callback">The delegate of type <see cref="ma_allocation_callbacks_realloc_proc"/>.</param>
         public void SetReallocProc(ma_allocation_callbacks_realloc_proc callback)
         {
             onRealloc = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
 
+        /// <summary>
+        /// Sets the custom memory free callback.
+        /// </summary>
+        /// <param name="callback">The delegate of type <see cref="ma_allocation_callbacks_free_proc"/>.</param>
         public void SetFreeProc(ma_allocation_callbacks_free_proc callback)
         {
             onFree = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
     }
 
+    /// <summary>
+    /// Describes the basic details about a playback or capture device, including format,
+    /// channel map, sample rate, and period configuration.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public unsafe struct ma_device_descriptor
     {
+        /// <summary>
+        /// A pointer to the ID of the device. Set to <c>null</c> to use the default device.
+        /// </summary>
         public ma_device_id_ptr pDeviceID;
+        /// <summary>
+        /// The share mode of the device (exclusive or shared).
+        /// </summary>
         public ma_share_mode shareMode;
+        /// <summary>
+        /// The sample format of the device (e.g. f32, s16).
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The number of channels.
+        /// </summary>
         public ma_uint32 channels;
+        /// <summary>
+        /// The sample rate in Hz.
+        /// </summary>
         public ma_uint32 sampleRate;
         private fixed ma_channel channelMap[MiniAudioNative.MA_MAX_CHANNELS];
+        /// <summary>
+        /// The period size in PCM frames.
+        /// </summary>
         public ma_uint32 periodSizeInFrames;
+        /// <summary>
+        /// The period size in milliseconds.
+        /// </summary>
         public ma_uint32 periodSizeInMilliseconds;
+        /// <summary>
+        /// The number of periods.
+        /// </summary>
         public ma_uint32 periodCount;
     }
 
+    /// <summary>
+    /// Represents a 3D vector with float components, used for positions, directions, and velocities
+    /// in spatialization calculations.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_vec3f
     {
+        /// <summary>
+        /// The X component of the vector.
+        /// </summary>
         public float x;
+        /// <summary>
+        /// The Y component of the vector.
+        /// </summary>
         public float y;
+        /// <summary>
+        /// The Z component of the vector.
+        /// </summary>
         public float z;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ma_vec3f"/> struct.
+        /// </summary>
+        /// <param name="x">The X component.</param>
+        /// <param name="y">The Y component.</param>
+        /// <param name="z">The Z component.</param>
         public ma_vec3f(float x, float y, float z)
         {
             this.x = x;
@@ -325,204 +526,583 @@ namespace MiniAudioEx.Native
             this.z = z;
         }
 
+        /// <summary>
+        /// Returns a string representation of the vector in the form "(x, y, z)".
+        /// </summary>
+        /// <returns>A string that represents the current vector.</returns>
         public override string ToString()
         {
             return "(" + x + ", " +  y + ", " + z + ")";
         }
     }
 
+    /// <summary>
+    /// A thread-safe 3D vector protected by a spinlock for atomic access.
+    /// Used for spatialization data that may be accessed from multiple threads.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_atomic_vec3f
     {
+        /// <summary>
+        /// The 3D vector value.
+        /// </summary>
         public ma_vec3f v;
+        /// <summary>
+        /// The spinlock used for atomic synchronization of the vector.
+        /// </summary>
         public ma_spinlock lck;
     }
 
+    /// <summary>
+    /// A typesafe atomic 32-bit boolean. The struct enforces atomic access at compile time
+    /// to prevent accidental non-atomic operations.
+    /// </summary>
     [StructLayout(LayoutKind.Explicit, Size = 4)]
     public struct ma_atomic_bool32
     {
+        /// <summary>
+        /// The underlying 32-bit value.
+        /// </summary>
         [FieldOffset(0)]
         public UInt32 value;
     }
 
+    /// <summary>
+    /// A typesafe atomic 32-bit unsigned integer. The struct enforces atomic access at compile time
+    /// to prevent accidental non-atomic operations.
+    /// </summary>
     [StructLayout(LayoutKind.Explicit, Size = 4)]
     public struct ma_atomic_uint32
     {
+        /// <summary>
+        /// The underlying 32-bit unsigned integer value.
+        /// </summary>
         [FieldOffset(0)]
         public UInt32 value;
     }
 
+    /// <summary>
+    /// A typesafe atomic 32-bit signed integer. The struct enforces atomic access at compile time
+    /// to prevent accidental non-atomic operations.
+    /// </summary>
     [StructLayout(LayoutKind.Explicit, Size = 4)]
     public struct ma_atomic_int32
     {
+        /// <summary>
+        /// The underlying 32-bit signed integer value.
+        /// </summary>
         [FieldOffset(0)]
         public Int32 value;
     }
 
+    /// <summary>
+    /// A typesafe atomic 64-bit unsigned integer. The struct enforces atomic access at compile time
+    /// to prevent accidental non-atomic operations.
+    /// </summary>
     [StructLayout(LayoutKind.Explicit, Size = 8)]
     public struct ma_atomic_uint64
     {
+        /// <summary>
+        /// The underlying 64-bit unsigned integer value.
+        /// </summary>
         [FieldOffset(0)]
         public UInt64 value;
     }
 
+    /// <summary>
+    /// A typesafe atomic float. The struct enforces atomic access at compile time
+    /// to prevent accidental non-atomic operations.
+    /// </summary>
     [StructLayout(LayoutKind.Explicit, Size = 4)]
     public struct ma_atomic_float
     {
+        /// <summary>
+        /// The underlying float value.
+        /// </summary>
         [FieldOffset(0)]
         public float value;
     }
 
+    /// <summary>
+    /// Configuration for a stereo panner. Specifies the audio format, channel count,
+    /// pan mode, and initial pan position.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_panner_config
     {
+        /// <summary>
+        /// The sample format of the audio data to be panned.
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The number of channels.
+        /// </summary>
         public ma_uint32 channels;
+        /// <summary>
+        /// The pan mode: <see cref="ma_pan_mode.ma_pan_mode_balance"/> (default) performs simple balance,
+        /// <see cref="ma_pan_mode.ma_pan_mode_pan"/> performs true panning where sound moves from one side to the other.
+        /// </summary>
         public ma_pan_mode mode;
+        /// <summary>
+        /// The pan position ranging from -1 (left) to +1 (right), where 0 is center. Defaults to 0.
+        /// </summary>
         public float pan;
     }
 
+    /// <summary>
+    /// Represents the runtime state of a stereo panner. Performs panning (balance or true pan)
+    /// on audio data.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_panner
     {
+        /// <summary>
+        /// The sample format of the audio data to be panned.
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The number of channels.
+        /// </summary>
         public ma_uint32 channels;
+        /// <summary>
+        /// The pan mode. <see cref="ma_pan_mode.ma_pan_mode_balance"/> for balance, <see cref="ma_pan_mode.ma_pan_mode_pan"/> for true pan.
+        /// </summary>
         public ma_pan_mode mode;
+        /// <summary>
+        /// The pan position ranging from -1 (left) to +1 (right), where 0 is center. Defaults to 0.
+        /// </summary>
         public float pan;  /* -1..1 where 0 is no pan, -1 is left side, +1 is right side. Defaults to 0. */
     }
 
+    /// <summary>
+    /// Configuration for initializing an engine node. An engine node is the base object for both
+    /// <c>ma_sound</c> and <c>ma_sound_group</c>.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_engine_node_config
     {
+        /// <summary>
+        /// A pointer to the engine that owns this node.
+        /// </summary>
         public ma_engine_ptr pEngine;
+        /// <summary>
+        /// The type of the engine node (sound or group).
+        /// </summary>
         public ma_engine_node_type type;
+        /// <summary>
+        /// The number of input channels.
+        /// </summary>
         public ma_uint32 channelsIn;
+        /// <summary>
+        /// The number of output channels.
+        /// </summary>
         public ma_uint32 channelsOut;
+        /// <summary>
+        /// The sample rate. Only used when the type is set to <see cref="ma_engine_node_type.ma_engine_node_type_sound"/>.
+        /// </summary>
         public ma_uint32 sampleRate;               /* Only used when the type is set to ma_engine_node_type_sound. */
+        /// <summary>
+        /// The number of frames to smooth over volume changes. Defaults to 0 in which case no smoothing is used.
+        /// </summary>
         public ma_uint32 volumeSmoothTimeInPCMFrames;  /* The number of frames to smooth over volume changes. Defaults to 0 in which case no smoothing is used. */
+        /// <summary>
+        /// Controls how a mono channel should be expanded to other channels when spatialization is disabled.
+        /// </summary>
         public ma_mono_expansion_mode monoExpansionMode;
+        /// <summary>
+        /// Pitching can be explicitly disabled with <c>MA_SOUND_FLAG_NO_PITCH</c> to optimize processing.
+        /// </summary>
         public ma_bool8 isPitchDisabled;           /* Pitching can be explicitly disabled with MA_SOUND_FLAG_NO_PITCH to optimize processing. */
+        /// <summary>
+        /// Spatialization can be explicitly disabled with <c>MA_SOUND_FLAG_NO_SPATIALIZATION</c>.
+        /// </summary>
         public ma_bool8 isSpatializationDisabled;  /* Spatialization can be explicitly disabled with MA_SOUND_FLAG_NO_SPATIALIZATION. */
+        /// <summary>
+        /// The index of the listener this node should always use for spatialization. If set to <c>MA_LISTENER_INDEX_CLOSEST</c> the engine will use the closest listener.
+        /// </summary>
         public ma_uint8 pinnedListenerIndex;       /* The index of the listener this node should always use for spatialization. If set to MA_LISTENER_INDEX_CLOSEST the engine will use the closest listener. */
+        /// <summary>
+        /// The resampler configuration for pitch shifting.
+        /// </summary>
         public ma_resampler_config resampling;
     }
 
+    /// <summary>
+    /// Base node object for both <c>ma_sound</c> and <c>ma_sound_group</c>. Contains all common
+    /// audio processing components such as fader, resampler, spatializer, panner, and volume gainer.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_engine_node
     {
+        /// <summary>
+        /// Must be the first member for compatibility with the ma_node API.
+        /// </summary>
         public ma_node_base baseNode;                              /* Must be the first member for compatibility with the ma_node API. */
+        /// <summary>
+        /// A pointer to the engine. Set based on the value from the config.
+        /// </summary>
         public ma_engine_ptr pEngine;                                 /* A pointer to the engine. Set based on the value from the config. */
+        /// <summary>
+        /// The sample rate of the input data. For sounds backed by a data source, this will be the data source's sample rate. Otherwise it'll be the engine's sample rate.
+        /// </summary>
         public ma_uint32 sampleRate;                               /* The sample rate of the input data. For sounds backed by a data source, this will be the data source's sample rate. Otherwise it'll be the engine's sample rate. */
+        /// <summary>
+        /// The number of frames to smooth over volume changes.
+        /// </summary>
         public ma_uint32 volumeSmoothTimeInPCMFrames;
+        /// <summary>
+        /// Controls how a mono channel should be expanded to other channels when spatialization is disabled.
+        /// </summary>
         public ma_mono_expansion_mode monoExpansionMode;
+        /// <summary>
+        /// The fader used for fade-in and fade-out effects.
+        /// </summary>
         public ma_fader fader;
+        /// <summary>
+        /// The resampler used for pitch shifting.
+        /// </summary>
         public ma_resampler resampler;                      /* For pitch shift. */
+        /// <summary>
+        /// The spatializer used for 3D audio positioning.
+        /// </summary>
         public ma_spatializer spatializer;
+        /// <summary>
+        /// The stereo panner.
+        /// </summary>
         public ma_panner panner;
+        /// <summary>
+        /// The volume gainer for smooth volume transitions. Only used if <see cref="volumeSmoothTimeInPCMFrames"/> is greater than 0.
+        /// </summary>
         public ma_gainer volumeGainer;                             /* This will only be used if volumeSmoothTimeInPCMFrames is > 0. */
+        /// <summary>
+        /// The volume level. Defaults to 1.
+        /// </summary>
         public float volume;                             /* Defaults to 1. */
+        /// <summary>
+        /// The pitch multiplier.
+        /// </summary>
         public float pitch;
+        /// <summary>
+        /// The previous pitch value, used for determining whether the resampler needs to be updated. Updated on the mixing thread.
+        /// </summary>
         public float oldPitch;                                     /* For determining whether or not the resampler needs to be updated to reflect the new pitch. The resampler will be updated on the mixing thread. */
+        /// <summary>
+        /// The previous Doppler pitch value, used for determining whether the resampler needs to be updated for Doppler effect changes.
+        /// </summary>
         public float oldDopplerPitch;                              /* For determining whether or not the resampler needs to be updated to take a new doppler pitch into account. */
+        /// <summary>
+        /// When set to true, pitching will be disabled which will allow the resampler to be bypassed to save computation.
+        /// </summary>
         public ma_bool32 isPitchDisabled;            /* When set to true, pitching will be disabled which will allow the resampler to be bypassed to save some computation. */
+        /// <summary>
+        /// Set to false by default. When set to false, will not have spatialization applied.
+        /// </summary>
         public ma_bool32 isSpatializationDisabled;   /* Set to false by default. When set to false, will not have spatialisation applied. */
+        /// <summary>
+        /// The index of the listener this node should always use for spatialization. If set to <c>MA_LISTENER_INDEX_CLOSEST</c> the engine will use the closest listener.
+        /// </summary>
         public ma_uint32 pinnedListenerIndex;        /* The index of the listener this node should always use for spatialization. If set to MA_LISTENER_INDEX_CLOSEST the engine will use the closest listener. */
         /* When setting a fade, it's not done immediately in ma_sound_set_fade(). It's deferred to the audio thread which means we need to store the settings here. */
+        /// <summary>
+        /// Deferred fade settings. Setting a fade is not done immediately in <c>ma_sound_set_fade()</c>; it is deferred to the audio thread which means the settings are stored here.
+        /// </summary>
         public fade_settings fadeSettings;
         /* Memory management. */
+        /// <summary>
+        /// Indicates whether this node owns its heap allocation.
+        /// </summary>
         public ma_bool8 _ownsHeap;
+        /// <summary>
+        /// A pointer to the heap-allocated internal data for this node.
+        /// </summary>
         public IntPtr _pHeap;
 
+        /// <summary>
+        /// Stores the deferred fade settings for an engine node. When a fade is set via <c>ma_sound_set_fade()</c>,
+        /// it is not applied immediately but deferred to the audio thread for thread safety.
+        /// </summary>
         [StructLayout(LayoutKind.Sequential)]
         public struct fade_settings
         {
+            /// <summary>
+            /// The volume at the beginning of the fade.
+            /// </summary>
             public float volumeBeg;
+            /// <summary>
+            /// The volume at the end of the fade.
+            /// </summary>
             public float volumeEnd;
+            /// <summary>
+            /// The total length of the fade in PCM frames. Defaults to <c>(~(ma_uint64)0)</c> which indicates that no fade should be applied.
+            /// </summary>
             public ma_uint64 fadeLengthInFrames;            /* <-- Defaults to (~(ma_uint64)0) which is used to indicate that no fade should be applied. */
+            /// <summary>
+            /// The absolute global time (in PCM frames) at which the fade should start.
+            /// </summary>
             public ma_uint64 absoluteGlobalTimeInFrames;    /* <-- The time to start the fade. */
         }
     }
 
+    /// <summary>
+    /// Configuration for initializing a <see cref="ma_engine"/> object. The engine is a high-level API
+    /// for managing and mixing sounds and effect processing, encapsulating a resource manager and a node graph.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_engine_config
     {
+        /// <summary>
+        /// A pointer to a resource manager. Can be null in which case a resource manager will be created for you.
+        /// </summary>
         public ma_resource_manager_ptr pResourceManager;          /* Can be null in which case a resource manager will be created for you. */
+        /// <summary>
+        /// A pointer to the miniaudio context.
+        /// </summary>
         public ma_context_ptr pContext;
+        /// <summary>
+        /// A pointer to a pre-initialized device. If set, the caller is responsible for calling <c>ma_engine_data_callback()</c> in the device's data callback.
+        /// </summary>
         public ma_device_ptr pDevice;                             /* If set, the caller is responsible for calling ma_engine_data_callback() in the device's data callback. */
+        /// <summary>
+        /// The ID of the playback device to use with the default listener.
+        /// </summary>
         public ma_device_id_ptr pPlaybackDeviceID;                /* The ID of the playback device to use with the default listener. */
+        /// <summary>
+        /// An optional custom device data callback. Can be null.
+        /// </summary>
         public IntPtr dataCallback;               /* Can be null. Can be used to provide a custom device data callback. */
+        /// <summary>
+        /// An optional notification callback for device events.
+        /// </summary>
         public IntPtr notificationCallback;
+        /// <summary>
+        /// A pointer to the log to use. When set to NULL, will use the context's log.
+        /// </summary>
         public ma_log_ptr pLog;                                   /* When set to NULL, will use the context's log. */
+        /// <summary>
+        /// The number of spatialization listeners. Must be between 1 and <c>MA_ENGINE_MAX_LISTENERS</c>.
+        /// </summary>
         public ma_uint32 listenerCount;                        /* Must be between 1 and MA_ENGINE_MAX_LISTENERS. */
+        /// <summary>
+        /// The number of channels to use when mixing and spatializing. When set to 0, will use the native channel count of the device.
+        /// </summary>
         public ma_uint32 channels;                             /* The number of channels to use when mixing and spatializing. When set to 0, will use the native channel count of the device. */
+        /// <summary>
+        /// The sample rate. When set to 0 will use the native sample rate of the device.
+        /// </summary>
         public ma_uint32 sampleRate;                           /* The sample rate. When set to 0 will use the native sample rate of the device. */
+        /// <summary>
+        /// If set to something other than 0, updates will always be exactly this size in frames.
+        /// </summary>
         public ma_uint32 periodSizeInFrames;                   /* If set to something other than 0, updates will always be exactly this size. The underlying device may be a different size, but from the perspective of the mixer that won't matter.*/
+        /// <summary>
+        /// The period size in milliseconds. Used if <see cref="periodSizeInFrames"/> is unset.
+        /// </summary>
         public ma_uint32 periodSizeInMilliseconds;             /* Used if periodSizeInFrames is unset. */
+        /// <summary>
+        /// The number of frames to interpolate the gain of spatialized sounds across. If set to 0, will use <see cref="gainSmoothTimeInMilliseconds"/>.
+        /// </summary>
         public ma_uint32 gainSmoothTimeInFrames;               /* The number of frames to interpolate the gain of spatialized sounds across. If set to 0, will use gainSmoothTimeInMilliseconds. */
+        /// <summary>
+        /// The number of milliseconds to interpolate the gain of spatialized sounds across. When set to 0, <see cref="gainSmoothTimeInFrames"/> will be used. If both are 0, a default value is used.
+        /// </summary>
         public ma_uint32 gainSmoothTimeInMilliseconds;         /* When set to 0, gainSmoothTimeInFrames will be used. If both are set to 0, a default value will be used. */
+        /// <summary>
+        /// Controls the default amount of smoothing to apply to volume changes to sounds. Defaults to 0. Higher values mean more smoothing at the expense of higher latency.
+        /// </summary>
         public ma_uint32 defaultVolumeSmoothTimeInPCMFrames;   /* Defaults to 0. Controls the default amount of smoothing to apply to volume changes to sounds. High values means more smoothing at the expense of high latency (will take longer to reach the new volume). */
+        /// <summary>
+        /// The pre-mix stack size in bytes. Used for internal processing in the node graph. Smaller values reduce the maximum depth of your node graph.
+        /// </summary>
         public ma_uint32 preMixStackSizeInBytes;               /* A stack is used for internal processing in the node graph. This allows you to configure the size of this stack. Smaller values will reduce the maximum depth of your node graph. You should rarely need to modify this. */
+        /// <summary>
+        /// Custom memory allocation callbacks.
+        /// </summary>
         public ma_allocation_callbacks allocationCallbacks;
+        /// <summary>
+        /// When set to true, requires an explicit call to <c>ma_engine_start()</c>. This is false by default, meaning the engine starts automatically in <c>ma_engine_init()</c>.
+        /// </summary>
         public ma_bool32 noAutoStart;                          /* When set to true, requires an explicit call to ma_engine_start(). This is false by default, meaning the engine will be started automatically in ma_engine_init(). */
+        /// <summary>
+        /// When set to true, don't create a default device. <c>ma_engine_read_pcm_frames()</c> can be called manually to read data.
+        /// </summary>
         public ma_bool32 noDevice;                             /* When set to true, don't create a default device. ma_engine_read_pcm_frames() can be called manually to read data. */
+        /// <summary>
+        /// Controls how the mono channel should be expanded to other channels when spatialization is disabled on a sound.
+        /// </summary>
         public ma_mono_expansion_mode monoExpansionMode;       /* Controls how the mono channel should be expanded to other channels when spatialization is disabled on a sound. */
+        /// <summary>
+        /// A pointer to a pre-allocated VFS object to use with the resource manager. This is ignored if <see cref="pResourceManager"/> is not NULL.
+        /// </summary>
         public ma_vfs_ptr pResourceManagerVFS;                    /* A pointer to a pre-allocated VFS object to use with the resource manager. This is ignored if pResourceManager is not NULL. */
+        /// <summary>
+        /// Fired at the end of each call to <c>ma_engine_read_pcm_frames()</c>. For engines that manage their own internal device, this fires from the audio thread.
+        /// </summary>
         public IntPtr onProcess;               /* Fired at the end of each call to ma_engine_read_pcm_frames(). For engine's that manage their own internal device (the default configuration), this will be fired from the audio thread, and you do not need to call ma_engine_read_pcm_frames() manually in order to trigger this. */
+        /// <summary>
+        /// User data that is passed into <see cref="onProcess"/>.
+        /// </summary>
         public IntPtr pProcessUserData;                         /* User data that's passed into onProcess. */
+        /// <summary>
+        /// The resampling config to use with the resource manager.
+        /// </summary>
         public ma_resampler_config resourceManagerResampling;  /* The resampling config to use with the resource manager. */
+        /// <summary>
+        /// The resampling config for the pitch and Doppler effects. You will typically want this to be a fast resampler.
+        /// </summary>
         public ma_resampler_config pitchResampling;            /* The resampling config for the pitch and Doppler effects. You will typically want this to be a fast resampler. For high quality stuff, it's recommended that you pre-resample. */
 
+        /// <summary>
+        /// Sets the device data callback delegate.
+        /// </summary>
+        /// <param name="callback">The <see cref="ma_device_data_proc"/> delegate.</param>
         public void SetDataProc(ma_device_data_proc callback)
         {
             dataCallback = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
 
+        /// <summary>
+        /// Sets the device notification callback delegate.
+        /// </summary>
+        /// <param name="callback">The <see cref="ma_device_notification_proc"/> delegate.</param>
         public void SetNotificationProc(ma_device_notification_proc callback)
         {
             notificationCallback = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
         
+        /// <summary>
+        /// Sets the engine process callback delegate.
+        /// </summary>
+        /// <param name="callback">The <see cref="ma_engine_process_proc"/> delegate.</param>
         public void SetEngineProcessProc(ma_engine_process_proc callback)
         {
             onProcess = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
     }
 
+    /// <summary>
+    /// Represents the runtime state of a miniaudio engine. The engine is a high-level API for managing
+    /// and mixing sounds and effect processing. It encapsulates a node graph and optionally a resource manager
+    /// and a playback device.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_engine
     {
+        /// <summary>
+        /// An engine is a node graph and must be the first member for compatibility with the ma_node_graph API.
+        /// </summary>
         public ma_node_graph nodeGraph;                        /* An engine is a node graph. It should be able to be plugged into any ma_node_graph API (with a cast) which means this must be the first member of this struct. */
+        /// <summary>
+        /// A pointer to the resource manager.
+        /// </summary>
         public ma_resource_manager_ptr pResourceManager;
+        /// <summary>
+        /// A pointer to the device. Optionally set via the config, otherwise allocated by the engine in <c>ma_engine_init()</c>.
+        /// </summary>
         public ma_device_ptr pDevice;                             /* Optionally set via the config, otherwise allocated by the engine in ma_engine_init(). */
+        /// <summary>
+        /// A pointer to the log.
+        /// </summary>
         public ma_log_ptr pLog;
+        /// <summary>
+        /// The sample rate of the engine.
+        /// </summary>
         public ma_uint32 sampleRate;
+        /// <summary>
+        /// The number of spatialization listeners.
+        /// </summary>
         public ma_uint32 listenerCount;
+        /// <summary>
+        /// The array of spatialization listeners. Each listener has a position, direction, and velocity for 3D audio.
+        /// </summary>
         public ma_spatializer_listener_array listeners;
+        /// <summary>
+        /// Custom memory allocation callbacks.
+        /// </summary>
         public ma_allocation_callbacks allocationCallbacks;
+        /// <summary>
+        /// Whether the engine owns the resource manager.
+        /// </summary>
         public ma_bool8 ownsResourceManager;
+        /// <summary>
+        /// Whether the engine owns the device.
+        /// </summary>
         public ma_bool8 ownsDevice;
+        /// <summary>
+        /// A spinlock for synchronizing access to the inlined sound list.
+        /// </summary>
         public ma_spinlock inlinedSoundLock;                   /* For synchronizing access to the inlined sound list. */
+        /// <summary>
+        /// The first inlined sound in the linked list. Inlined sounds are tracked in a linked list.
+        /// </summary>
         public ma_sound_inlined_ptr pInlinedSoundHead;            /* The first inlined sound. Inlined sounds are tracked in a linked list. */
+        /// <summary>
+        /// The total number of allocated inlined sound objects. Used for debugging.
+        /// </summary>
         public UInt32 inlinedSoundCount;      /* The total number of allocated inlined sound objects. Used for debugging. */
+        /// <summary>
+        /// The number of frames to interpolate the gain of spatialized sounds across.
+        /// </summary>
         public ma_uint32 gainSmoothTimeInFrames;               /* The number of frames to interpolate the gain of spatialized sounds across. */
+        /// <summary>
+        /// The default amount of smoothing to apply to volume changes to sounds.
+        /// </summary>
         public ma_uint32 defaultVolumeSmoothTimeInPCMFrames;
+        /// <summary>
+        /// Controls how a mono channel should be expanded to other channels when spatialization is disabled on a sound.
+        /// </summary>
         public ma_mono_expansion_mode monoExpansionMode;
+        /// <summary>
+        /// The engine process callback, fired at the end of each call to <c>ma_engine_read_pcm_frames()</c>.
+        /// </summary>
         public IntPtr onProcess;
+        /// <summary>
+        /// User data that is passed into <see cref="onProcess"/>.
+        /// </summary>
         public IntPtr pProcessUserData;
+        /// <summary>
+        /// The resampling configuration for pitch effects.
+        /// </summary>
         public ma_resampler_config pitchResamplingConfig;
 
+        /// <summary>
+        /// Sets the engine process callback delegate.
+        /// </summary>
+        /// <param name="callback">The <see cref="ma_engine_process_proc"/> delegate.</param>
         public void SetProcessProc(ma_engine_process_proc callback)
         {
             onProcess = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
 
+        /// <summary>
+        /// Represents a fixed-size array of spatialization listeners. The engine supports up to
+        /// <c>MA_ENGINE_MAX_LISTENERS</c> listeners (default 4) for 3D audio spatialization.
+        /// Provides an indexer for accessing individual listeners.
+        /// </summary>
         [StructLayout(LayoutKind.Sequential)]
         public unsafe struct ma_spatializer_listener_array
         {
+            /// <summary>
+            /// Listener at index 0.
+            /// </summary>
             public ma_spatializer_listener l0;
+            /// <summary>
+            /// Listener at index 1.
+            /// </summary>
             public ma_spatializer_listener l1;
+            /// <summary>
+            /// Listener at index 2.
+            /// </summary>
             public ma_spatializer_listener l2;
+            /// <summary>
+            /// Listener at index 3.
+            /// </summary>
             public ma_spatializer_listener l3;
+            /// <summary>
+            /// Gets or sets the <see cref="ma_spatializer_listener"/> at the specified index.
+            /// </summary>
+            /// <param name="index">The zero-based index of the listener to get or set.</param>
+            /// <returns>The <see cref="ma_spatializer_listener"/> at the specified index.</returns>
+            /// <exception cref="IndexOutOfRangeException">Thrown when <paramref name="index"/> is less than 0 or greater than or equal to <c>MA_ENGINE_MAX_LISTENERS</c>.</exception>
             public ref ma_spatializer_listener this[int index]
             {
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -541,72 +1121,178 @@ namespace MiniAudioEx.Native
         }
     }
 
+    /// <summary>
+    /// Configuration for a procedural data source.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_procedural_data_source_config
     {
+        /// <summary>
+        /// The sample format of the data source.
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The number of channels in the data source.
+        /// </summary>
         public ma_uint32 channels;
+        /// <summary>
+        /// The sample rate of the data source.
+        /// </summary>
         public ma_uint32 sampleRate;
+        /// <summary>
+        /// Function pointer to the procedural callback.
+        /// </summary>
         public IntPtr callback;
+        /// <summary>
+        /// User data pointer passed to the callback.
+        /// </summary>
         public IntPtr pUserData;
 
+        /// <summary>
+        /// Sets the procedural data source callback.
+        /// </summary>
+        /// <param name="callback">The callback delegate to invoke for generating data.</param>
         public void SetCallback(ma_procedural_data_source_proc callback)
         {
             this.callback = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
     }
 
+    /// <summary>
+    /// Represents a procedural data source at runtime. Generates audio data programmatically via a callback.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_procedural_data_source
     {
+        /// <summary>
+        /// The base data source.
+        /// </summary>
         public ma_data_source_base ds;
+        /// <summary>
+        /// The procedural data source configuration.
+        /// </summary>
         public ma_procedural_data_source_config config;
     }
 
+    /// <summary>
+    /// Configuration for a fader that applies a volume ramp over a specified duration.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_fader_config
     {
+        /// <summary>
+        /// The sample format.
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The number of channels.
+        /// </summary>
         public ma_uint32 channels;
+        /// <summary>
+        /// The sample rate.
+        /// </summary>
         public ma_uint32 sampleRate;
     }
 
+    /// <summary>
+    /// Represents a fader at runtime. Applies a linear volume ramp from one volume to another over a specified number of frames.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_fader
     {
+        /// <summary>
+        /// The fader configuration.
+        /// </summary>
         public ma_fader_config config;
+        /// <summary>
+        /// The starting volume. If both volumeBeg and volumeEnd equal 1, no fading happens and the fader acts as a passthrough.
+        /// </summary>
         public float volumeBeg;            /* If volumeBeg and volumeEnd is equal to 1, no fading happens (ma_fader_process_pcm_frames() will run as a passthrough). */
+        /// <summary>
+        /// The ending volume.
+        /// </summary>
         public float volumeEnd;
+        /// <summary>
+        /// The total length of the fade in PCM frames.
+        /// </summary>
         public ma_uint64 lengthInFrames;   /* The total length of the fade. */
+        /// <summary>
+        /// The current time in frames. Incremented by ma_fader_process_pcm_frames(). Signed because it will be offset by startOffsetInFrames in set_fade_ex().
+        /// </summary>
         public ma_int64 cursorInFrames;   /* The current time in frames. Incremented by ma_fader_process_pcm_frames(). Signed because it'll be offset by startOffsetInFrames in set_fade_ex(). */
     }
 
+    /// <summary>
+    /// Holds a log callback function pointer and associated user data.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_log_callback
     {
+        /// <summary>
+        /// Function pointer to the log callback.
+        /// </summary>
         public IntPtr onLog;
+        /// <summary>
+        /// User data pointer passed to the log callback.
+        /// </summary>
         public IntPtr pUserData;
+        /// <summary>
+        /// Sets the log callback.
+        /// </summary>
+        /// <param name="callback">The log callback delegate.</param>
         public void SetLogCallback(ma_log_callback_proc callback)
         {
             onLog = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
     }
 
+    /// <summary>
+    /// Represents the log system. Manages registered log callbacks and routes log messages to them.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_log
     {
+        /// <summary>
+        /// Array of registered log callbacks.
+        /// </summary>
         public ma_log_callback_array callbacks;
+        /// <summary>
+        /// The number of registered callbacks.
+        /// </summary>
         public ma_uint32 callbackCount;
+        /// <summary>
+        /// Allocation callbacks used for internal memory management. Stored persistently because ma_log_postv() might need to allocate a buffer on the heap.
+        /// </summary>
         public ma_allocation_callbacks allocationCallbacks; /* Need to store these persistently because ma_log_postv() might need to allocate a buffer on the heap. */
         //There is a mutex here but the size depends on platform
 
+        /// <summary>
+        /// Fixed-size array of log callbacks with an indexer for access.
+        /// </summary>
         [StructLayout(LayoutKind.Sequential)]
         public struct ma_log_callback_array
         {
+            /// <summary>
+            /// Callback slot 0.
+            /// </summary>
             public ma_log_callback cb0;
+            /// <summary>
+            /// Callback slot 1.
+            /// </summary>
             public ma_log_callback cb1;
+            /// <summary>
+            /// Callback slot 2.
+            /// </summary>
             public ma_log_callback cb2;
+            /// <summary>
+            /// Callback slot 3.
+            /// </summary>
             public ma_log_callback cb3;
+            /// <summary>
+            /// Indexed access to the callback array. Bounds-checked between 0 and MA_MAX_LOG_CALLBACKS-1.
+            /// </summary>
+            /// <param name="index">The index of the callback to access.</param>
+            /// <returns>A reference to the callback at the given index.</returns>
             public unsafe ref ma_log_callback this[int index]
             {
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -625,283 +1311,732 @@ namespace MiniAudioEx.Native
         }
     }
 
+    /// <summary>
+    /// Configuration for a miniaudio context. Holds backend-specific settings and optional log system reference.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_context_config
     {
+        /// <summary>
+        /// Pointer to the log system. Can be null to use no logging.
+        /// </summary>
         public ma_log_ptr pLog;
+        /// <summary>
+        /// The thread priority to use internally.
+        /// </summary>
         public ma_thread_priority threadPriority;
+        /// <summary>
+        /// The thread stack size to use internally.
+        /// </summary>
         public size_t threadStackSize;
+        /// <summary>
+        /// Application-defined user data.
+        /// </summary>
         public IntPtr pUserData;
+        /// <summary>
+        /// Allocation callbacks used for memory management.
+        /// </summary>
         public ma_allocation_callbacks allocationCallbacks;
+        /// <summary>
+        /// DirectSound backend-specific configuration.
+        /// </summary>
         public dsound_info dsound;
+        /// <summary>
+        /// ALSA backend-specific configuration.
+        /// </summary>
         public alsa_info alsa;
+        /// <summary>
+        /// PulseAudio backend-specific configuration.
+        /// </summary>
         public pulse_info pulse;
+        /// <summary>
+        /// Core Audio backend-specific configuration.
+        /// </summary>
         public coreaudio_info coreaudio;
+        /// <summary>
+        /// JACK backend-specific configuration.
+        /// </summary>
         public jack_info jack;
+        /// <summary>
+        /// Custom backend callbacks.
+        /// </summary>
         public ma_backend_callbacks custom;
 
+        /// <summary>
+        /// DirectSound-specific context configuration.
+        /// </summary>
         [StructLayout(LayoutKind.Sequential)]
         public struct dsound_info
         {
+            /// <summary>
+            /// Optional window handle to pass into SetCooperativeLevel(). Will default to the foreground window, and if that fails, the desktop window.
+            /// </summary>
             public ma_handle hWnd; /* HWND. Optional window handle to pass into SetCooperativeLevel(). Will default to the foreground window, and if that fails, the desktop window. */
         }
 
+        /// <summary>
+        /// ALSA-specific context configuration.
+        /// </summary>
         [StructLayout(LayoutKind.Sequential)]
         public struct alsa_info
         {
+            /// <summary>
+            /// When set to true, uses verbose device enumeration.
+            /// </summary>
             public ma_bool32 useVerboseDeviceEnumeration;
         }
 
+        /// <summary>
+        /// PulseAudio-specific context configuration.
+        /// </summary>
         [StructLayout(LayoutKind.Sequential)]
         public struct pulse_info
         {
+            /// <summary>
+            /// The application name string to use with PulseAudio.
+            /// </summary>
             public IntPtr pApplicationName;
+            /// <summary>
+            /// The server name string. Set to IntPtr.Zero to use the default server.
+            /// </summary>
             public IntPtr pServerName;
+            /// <summary>
+            /// Enables autospawning of the PulseAudio daemon if necessary.
+            /// </summary>
             public ma_bool32 tryAutoSpawn; /* Enables autospawning of the PulseAudio daemon if necessary. */
         }
 
+        /// <summary>
+        /// Core Audio-specific context configuration (iOS/macOS).
+        /// </summary>
         [StructLayout(LayoutKind.Sequential)]
         public struct coreaudio_info
         {
+            /// <summary>
+            /// The iOS session category.
+            /// </summary>
             public ma_ios_session_category sessionCategory;
+            /// <summary>
+            /// Additional iOS session category options.
+            /// </summary>
             public ma_uint32 sessionCategoryOptions;
+            /// <summary>
+            /// iOS only. When set to true, does not perform an explicit [[AVAudioSession sharedInstance] setActive:true] on initialization.
+            /// </summary>
             public ma_bool32 noAudioSessionActivate;   /* iOS only. When set to true, does not perform an explicit [[AVAudioSession sharedInstace] setActive:true] on initialization. */
+            /// <summary>
+            /// iOS only. When set to true, does not perform an explicit [[AVAudioSession sharedInstance] setActive:false] on uninitialization.
+            /// </summary>
             public ma_bool32 noAudioSessionDeactivate; /* iOS only. When set to true, does not perform an explicit [[AVAudioSession sharedInstace] setActive:false] on uninitialization. */
         }
 
+        /// <summary>
+        /// JACK-specific context configuration.
+        /// </summary>
         [StructLayout(LayoutKind.Sequential)]
         public struct jack_info
         {
+            /// <summary>
+            /// The client name to use with the JACK server.
+            /// </summary>
             public IntPtr pClientName;
+            /// <summary>
+            /// When set to true, attempts to start the JACK server if it is not already running.
+            /// </summary>
             public ma_bool32 tryStartServer;
         }
     }
 
+    /// <summary>
+    /// Represents a miniaudio context at runtime. Acts as the root object for managing backends, devices, and logging.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_context
     {
+        /// <summary>
+        /// Backend callbacks for the underlying audio backend implementation.
+        /// </summary>
         public ma_backend_callbacks callbacks;
+        /// <summary>
+        /// The active backend (DirectSound, ALSA, etc.).
+        /// </summary>
         public ma_backend backend;                 /* DirectSound, ALSA, etc. */
+        /// <summary>
+        /// Pointer to the log system.
+        /// </summary>
         public ma_log_ptr pLog;
+        /// <summary>
+        /// Internal log instance used when the context owns the log. In this case, pLog will be set to point here.
+        /// </summary>
         public ma_log log; /* Only used if the log is owned by the context. The pLog member will be set to &log in this case. */
+        /// <summary>
+        /// The thread priority used internally.
+        /// </summary>
         public ma_thread_priority threadPriority;
+        /// <summary>
+        /// The thread stack size used internally.
+        /// </summary>
         public size_t threadStackSize;
+        /// <summary>
+        /// Application-defined user data.
+        /// </summary>
         public IntPtr pUserData;
+        /// <summary>
+        /// Allocation callbacks used for memory management.
+        /// </summary>
         public ma_allocation_callbacks allocationCallbacks;
         //More (variable sized) fields here...
     }
 
+    /// <summary>
+    /// Represents a notification for a single stage in the resource manager pipeline (e.g. initialization or completion).
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_resource_manager_pipeline_stage_notification
     {
+        /// <summary>
+        /// Pointer to an asynchronous notification to be signaled.
+        /// </summary>
         public ma_async_notification_ptr pNotification;
+        /// <summary>
+        /// Pointer to a fence to be signaled.
+        /// </summary>
         public ma_fence_ptr pFence;
     }
 
+    /// <summary>
+    /// Holds pipeline stage notifications for init (decoder initialization) and done (decoding fully completed) events.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_resource_manager_pipeline_notifications
     {
+        /// <summary>
+        /// Notification for initialization of the decoder.
+        /// </summary>
         public ma_resource_manager_pipeline_stage_notification init;    /* Initialization of the decoder. */
+        /// <summary>
+        /// Notification for decoding fully completed.
+        /// </summary>
         public ma_resource_manager_pipeline_stage_notification done;    /* Decoding fully completed. */
     }
 
+    /// <summary>
+    /// Holds function pointers for backend callbacks, allowing custom audio backends to be implemented.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_backend_callbacks
     {
+        /// <summary>
+        /// Function pointer for context initialization.
+        /// </summary>
         public IntPtr onContextInit;
+        /// <summary>
+        /// Function pointer for context uninitialization.
+        /// </summary>
         public IntPtr onContextUninit;
+        /// <summary>
+        /// Function pointer for enumerating devices on the context.
+        /// </summary>
         public IntPtr onContextEnumerateDevices;
+        /// <summary>
+        /// Function pointer for getting device info from the context.
+        /// </summary>
         public IntPtr onContextGetDeviceInfo;
+        /// <summary>
+        /// Function pointer for device initialization.
+        /// </summary>
         public IntPtr onDeviceInit;
+        /// <summary>
+        /// Function pointer for device uninitialization.
+        /// </summary>
         public IntPtr onDeviceUninit;
+        /// <summary>
+        /// Function pointer for starting the device.
+        /// </summary>
         public IntPtr onDeviceStart;
+        /// <summary>
+        /// Function pointer for stopping the device.
+        /// </summary>
         public IntPtr onDeviceStop;
+        /// <summary>
+        /// Function pointer for reading data from the device.
+        /// </summary>
         public IntPtr onDeviceRead;
+        /// <summary>
+        /// Function pointer for writing data to the device.
+        /// </summary>
         public IntPtr onDeviceWrite;
+        /// <summary>
+        /// Function pointer for the device data loop.
+        /// </summary>
         public IntPtr onDeviceDataLoop;
+        /// <summary>
+        /// Function pointer for waking up the device data loop.
+        /// </summary>
         public IntPtr onDeviceDataLoopWakeup;
+        /// <summary>
+        /// Function pointer for getting device information.
+        /// </summary>
         public IntPtr onDeviceGetInfo;
 
+        /// <summary>
+        /// Sets the context initialization callback.
+        /// </summary>
+        /// <param name="callback">The callback delegate.</param>
         public void Set(ma_backend_context_init_proc callback)
         {
             onContextInit = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
 
+        /// <summary>
+        /// Sets the context uninitialization callback.
+        /// </summary>
+        /// <param name="callback">The callback delegate.</param>
         public void Set(ma_backend_context_uninit_proc callback)
         {
             onContextUninit = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
 
+        /// <summary>
+        /// Sets the context device enumeration callback.
+        /// </summary>
+        /// <param name="callback">The callback delegate.</param>
         public void Set(ma_backend_context_enumerate_devices_proc callback)
         {
             onContextEnumerateDevices = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
 
+        /// <summary>
+        /// Sets the context get device info callback.
+        /// </summary>
+        /// <param name="callback">The callback delegate.</param>
         public void Set(ma_backend_context_get_device_info_proc callback)
         {
             onContextGetDeviceInfo = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
 
+        /// <summary>
+        /// Sets the device initialization callback.
+        /// </summary>
+        /// <param name="callback">The callback delegate.</param>
         public void Set(ma_backend_device_init_proc callback)
         {
             onDeviceInit = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
 
+        /// <summary>
+        /// Sets the device uninitialization callback.
+        /// </summary>
+        /// <param name="callback">The callback delegate.</param>
         public void Set(ma_backend_device_uninit_proc callback)
         {
             onDeviceUninit = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
 
+        /// <summary>
+        /// Sets the device start callback.
+        /// </summary>
+        /// <param name="callback">The callback delegate.</param>
         public void Set(ma_backend_device_start_proc callback)
         {
             onDeviceStart = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
 
+        /// <summary>
+        /// Sets the device stop callback.
+        /// </summary>
+        /// <param name="callback">The callback delegate.</param>
         public void Set(ma_backend_device_stop_proc callback)
         {
             onDeviceStop = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
 
+        /// <summary>
+        /// Sets the device read callback.
+        /// </summary>
+        /// <param name="callback">The callback delegate.</param>
         public void Set(ma_backend_device_read_proc callback)
         {
             onDeviceRead = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
 
+        /// <summary>
+        /// Sets the device write callback.
+        /// </summary>
+        /// <param name="callback">The callback delegate.</param>
         public void Set(ma_backend_device_write_proc callback)
         {
             onDeviceWrite = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
 
+        /// <summary>
+        /// Sets the device data loop callback.
+        /// </summary>
+        /// <param name="callback">The callback delegate.</param>
         public void Set(ma_backend_device_dataloop_proc callback)
         {
             onDeviceDataLoop = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
 
+        /// <summary>
+        /// Sets the device data loop wakeup callback.
+        /// </summary>
+        /// <param name="callback">The callback delegate.</param>
         public void Set(ma_backend_device_dataloop_wakeup_proc callback)
         {
             onDeviceDataLoopWakeup = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
 
+        /// <summary>
+        /// Sets the device get info callback.
+        /// </summary>
+        /// <param name="callback">The callback delegate.</param>
         public void Set(ma_backend_device_get_info_proc callback)
         {
             onDeviceGetInfo = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
     }
 
+    /// <summary>
+    /// Configuration for a sound that can be loaded from a file, an existing data source, or the resource manager.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_sound_config
     {
+        /// <summary>
+        /// Set this to load from the resource manager using an ANSI file path.
+        /// </summary>
         public IntPtr pFilePath;                      /* Set this to load from the resource manager. */
+        /// <summary>
+        /// Set this to load from the resource manager using a wide-char file path.
+        /// </summary>
         public IntPtr pFilePathW;                  /* Set this to load from the resource manager. */
+        /// <summary>
+        /// Set this to load from an existing data source.
+        /// </summary>
         public ma_data_source_ptr pDataSource;                /* Set this to load from an existing data source. */
+        /// <summary>
+        /// If set, the sound will be attached to an input of this node. This can be a ma_sound. If null, the sound will be attached directly to the endpoint unless MA_SOUND_FLAG_NO_DEFAULT_ATTACHMENT is set in flags.
+        /// </summary>
         public ma_node_ptr pInitialAttachment;                /* If set, the sound will be attached to an input of this node. This can be set to a ma_sound. If set to NULL, the sound will be attached directly to the endpoint unless MA_SOUND_FLAG_NO_DEFAULT_ATTACHMENT is set in `flags`. */
+        /// <summary>
+        /// The index of the input bus of pInitialAttachment to attach the sound to.
+        /// </summary>
         public ma_uint32 initialAttachmentInputBusIndex;   /* The index of the input bus of pInitialAttachment to attach the sound to. */
+        /// <summary>
+        /// Ignored if using a data source as input (the data source's channel count will be used always). Otherwise, setting to 0 will cause the engine's channel count to be used.
+        /// </summary>
         public ma_uint32 channelsIn;                       /* Ignored if using a data source as input (the data source's channel count will be used always). Otherwise, setting to 0 will cause the engine's channel count to be used. */
+        /// <summary>
+        /// Set this to 0 (default) to use the engine's channel count. Set to MA_SOUND_SOURCE_CHANNEL_COUNT to use the data source's channel count.
+        /// </summary>
         public ma_uint32 channelsOut;                      /* Set this to 0 (default) to use the engine's channel count. Set to MA_SOUND_SOURCE_CHANNEL_COUNT to use the data source's channel count (only used if using a data source as input). */
+        /// <summary>
+        /// Controls how the mono channel should be expanded to other channels when spatialization is disabled on a sound.
+        /// </summary>
         public ma_mono_expansion_mode monoExpansionMode;   /* Controls how the mono channel should be expanded to other channels when spatialization is disabled on a sound. */
+        /// <summary>
+        /// A combination of MA_SOUND_FLAG_* flags.
+        /// </summary>
         public ma_uint32 flags;                            /* A combination of MA_SOUND_FLAG_* flags. */
+        /// <summary>
+        /// The number of frames to smooth over volume changes. Defaults to 0 in which case no smoothing is used.
+        /// </summary>
         public ma_uint32 volumeSmoothTimeInPCMFrames;      /* The number of frames to smooth over volume changes. Defaults to 0 in which case no smoothing is used. */
+        /// <summary>
+        /// Initializes the sound such that it is seeked to this location by default.
+        /// </summary>
         public ma_uint64 initialSeekPointInPCMFrames;      /* Initializes the sound such that it's seeked to this location by default. */
+        /// <summary>
+        /// The beginning of the range to play, in PCM frames.
+        /// </summary>
         public ma_uint64 rangeBegInPCMFrames;
+        /// <summary>
+        /// The end of the range to play, in PCM frames.
+        /// </summary>
         public ma_uint64 rangeEndInPCMFrames;
+        /// <summary>
+        /// The loop start point, in PCM frames.
+        /// </summary>
         public ma_uint64 loopPointBegInPCMFrames;
+        /// <summary>
+        /// The loop end point, in PCM frames.
+        /// </summary>
         public ma_uint64 loopPointEndInPCMFrames;
+        /// <summary>
+        /// Function pointer to the end callback, called when the sound finishes playing.
+        /// </summary>
         public IntPtr endCallback;
+        /// <summary>
+        /// User data pointer passed to the end callback.
+        /// </summary>
         public IntPtr pEndCallbackUserData;
+        /// <summary>
+        /// Resampler configuration for pitch changes.
+        /// </summary>
         public ma_resampler_config pitchResampling;
+        /// <summary>
+        /// Notifications for initialization stages.
+        /// </summary>
         public ma_resource_manager_pipeline_notifications initNotifications;
+        /// <summary>
+        /// Deprecated. Use initNotifications instead. Released when the resource manager has finished decoding the entire sound. Not used with streams.
+        /// </summary>
         public ma_fence_ptr pDoneFence;                       /* Deprecated. Use initNotifications instead. Released when the resource manager has finished decoding the entire sound. Not used with streams. */
+        /// <summary>
+        /// Deprecated. Use the MA_SOUND_FLAG_LOOPING flag in flags instead.
+        /// </summary>
         public ma_bool32 isLooping;                        /* Deprecated. Use the MA_SOUND_FLAG_LOOPING flag in `flags` instead. */
 
+        /// <summary>
+        /// Sets the end callback for the sound.
+        /// </summary>
+        /// <param name="callback">The callback delegate invoked when the sound finishes playing.</param>
         public void SetEndCallback(ma_sound_end_proc callback)
         {
             endCallback = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
     }
 
+    /// <summary>
+    /// Represents a sound at runtime. Wraps an engine node with data source access, seeking, and end-of-sound tracking.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_sound
     {
+        /// <summary>
+        /// Must be the first member for compatibility with the ma_node API.
+        /// </summary>
         public ma_engine_node engineNode;          /* Must be the first member for compatibility with the ma_node API. */
+        /// <summary>
+        /// Pointer to the underlying data source.
+        /// </summary>
         public ma_data_source_ptr pDataSource;
+        /// <summary>
+        /// The PCM frame index to seek to in the mixing thread. Set to (~(ma_uint64)0) to not perform any seeking.
+        /// </summary>
         public ma_uint64 seekTarget; /* The PCM frame index to seek to in the mixing thread. Set to (~(ma_uint64)0) to not perform any seeking. */
+        /// <summary>
+        /// Whether the sound has reached the end.
+        /// </summary>
         public ma_bool32 atEnd;
+        /// <summary>
+        /// Function pointer to the end callback.
+        /// </summary>
         public IntPtr endCallback;
+        /// <summary>
+        /// User data passed to the end callback.
+        /// </summary>
         public IntPtr pEndCallbackUserData;
+        /// <summary>
+        /// Processing cache buffer. Will be null if pDataSource is null.
+        /// </summary>
         public IntPtr pProcessingCache;            /* Will be null if pDataSource is null. */ 
+        /// <summary>
+        /// Number of frames remaining in the processing cache.
+        /// </summary>
         public ma_uint32 processingCacheFramesRemaining;
+        /// <summary>
+        /// Capacity of the processing cache.
+        /// </summary>
         public ma_uint32 processingCacheCap;
+        /// <summary>
+        /// Whether this sound owns its data source.
+        /// </summary>
         public ma_bool8 ownsDataSource;
 
         /*
         We're declaring a resource manager data source object here to save us a malloc when loading a
         sound via the resource manager, which I *think* will be the most common scenario.
         */
+        /// <summary>
+        /// Resource manager data source pointer, stored inline to save a malloc when loading via the resource manager.
+        /// </summary>
         public ma_resource_manager_data_source_ptr pResourceManagerDataSource;
 
+        /// <summary>
+        /// Sets the end callback for the sound.
+        /// </summary>
+        /// <param name="callback">The callback delegate invoked when the sound finishes playing.</param>
         public void SetEndCallback(ma_sound_end_proc callback)
         {
             endCallback = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
     }
 
+    /// <summary>
+    /// Represents a sound inlined in a linked list. Contains next and previous pointers for list traversal.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_sound_inlined
     {
+        /// <summary>
+        /// The sound itself.
+        /// </summary>
         public ma_sound sound;
+        /// <summary>
+        /// Pointer to the next sound in the list.
+        /// </summary>
         public ma_sound_inlined_ptr pNext;
+        /// <summary>
+        /// Pointer to the previous sound in the list.
+        /// </summary>
         public ma_sound_inlined_ptr pPrev;
     }
 
+    /// <summary>
+    /// Configuration for a sound group. Groups multiple sounds together for collective control.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_sound_group_config
     {
+        /// <summary>
+        /// Set this to load from the resource manager using an ANSI file path.
+        /// </summary>
         public IntPtr pFilePath;                      /* Set this to load from the resource manager. */
+        /// <summary>
+        /// Set this to load from the resource manager using a wide-char file path.
+        /// </summary>
         public IntPtr pFilePathW;                  /* Set this to load from the resource manager. */
+        /// <summary>
+        /// Set this to load from an existing data source.
+        /// </summary>
         public ma_data_source_ptr pDataSource;                /* Set this to load from an existing data source. */
+        /// <summary>
+        /// If set, the sound will be attached to an input of this node. This can be a ma_sound. If null, the sound will be attached directly to the endpoint unless MA_SOUND_FLAG_NO_DEFAULT_ATTACHMENT is set in flags.
+        /// </summary>
         public ma_node_ptr pInitialAttachment;                /* If set, the sound will be attached to an input of this node. This can be set to a ma_sound. If set to NULL, the sound will be attached directly to the endpoint unless MA_SOUND_FLAG_NO_DEFAULT_ATTACHMENT is set in `flags`. */
+        /// <summary>
+        /// The index of the input bus of pInitialAttachment to attach the sound to.
+        /// </summary>
         public ma_uint32 initialAttachmentInputBusIndex;   /* The index of the input bus of pInitialAttachment to attach the sound to. */
+        /// <summary>
+        /// Ignored if using a data source as input. Otherwise, setting to 0 will cause the engine's channel count to be used.
+        /// </summary>
         public ma_uint32 channelsIn;                       /* Ignored if using a data source as input (the data source's channel count will be used always). Otherwise, setting to 0 will cause the engine's channel count to be used. */
+        /// <summary>
+        /// Set this to 0 (default) to use the engine's channel count. Set to MA_SOUND_SOURCE_CHANNEL_COUNT to use the data source's channel count.
+        /// </summary>
         public ma_uint32 channelsOut;                      /* Set this to 0 (default) to use the engine's channel count. Set to MA_SOUND_SOURCE_CHANNEL_COUNT to use the data source's channel count (only used if using a data source as input). */
+        /// <summary>
+        /// Controls how the mono channel should be expanded to other channels when spatialization is disabled on a sound.
+        /// </summary>
         public ma_mono_expansion_mode monoExpansionMode;   /* Controls how the mono channel should be expanded to other channels when spatialization is disabled on a sound. */
+        /// <summary>
+        /// A combination of MA_SOUND_FLAG_* flags.
+        /// </summary>
         public ma_uint32 flags;                            /* A combination of MA_SOUND_FLAG_* flags. */
+        /// <summary>
+        /// The number of frames to smooth over volume changes. Defaults to 0 in which case no smoothing is used.
+        /// </summary>
         public ma_uint32 volumeSmoothTimeInPCMFrames;      /* The number of frames to smooth over volume changes. Defaults to 0 in which case no smoothing is used. */
+        /// <summary>
+        /// Initializes the sound such that it is seeked to this location by default.
+        /// </summary>
         public ma_uint64 initialSeekPointInPCMFrames;      /* Initializes the sound such that it's seeked to this location by default. */
+        /// <summary>
+        /// The beginning of the range to play, in PCM frames.
+        /// </summary>
         public ma_uint64 rangeBegInPCMFrames;
+        /// <summary>
+        /// The end of the range to play, in PCM frames.
+        /// </summary>
         public ma_uint64 rangeEndInPCMFrames;
+        /// <summary>
+        /// The loop start point, in PCM frames.
+        /// </summary>
         public ma_uint64 loopPointBegInPCMFrames;
+        /// <summary>
+        /// The loop end point, in PCM frames.
+        /// </summary>
         public ma_uint64 loopPointEndInPCMFrames;
+        /// <summary>
+        /// Function pointer to the end callback, called when the sound finishes playing.
+        /// </summary>
         public IntPtr endCallback;
+        /// <summary>
+        /// User data pointer passed to the end callback.
+        /// </summary>
         public IntPtr pEndCallbackUserData;
+        /// <summary>
+        /// Notifications for initialization stages.
+        /// </summary>
         public ma_resource_manager_pipeline_notifications initNotifications;
+        /// <summary>
+        /// Deprecated. Use initNotifications instead. Released when the resource manager has finished decoding the entire sound. Not used with streams.
+        /// </summary>
         public ma_fence_ptr pDoneFence;                       /* Deprecated. Use initNotifications instead. Released when the resource manager has finished decoding the entire sound. Not used with streams. */
+        /// <summary>
+        /// Deprecated. Use the MA_SOUND_FLAG_LOOPING flag in flags instead.
+        /// </summary>
         public ma_bool32 isLooping;                        /* Deprecated. Use the MA_SOUND_FLAG_LOOPING flag in `flags` instead. */
 
+        /// <summary>
+        /// Sets the end callback for the sound group.
+        /// </summary>
+        /// <param name="callback">The callback delegate invoked when the sound finishes playing.</param>
         public void SetEndCallback(ma_sound_end_proc callback)
         {
             endCallback = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
     }
 
+    /// <summary>
+    /// Describes a native data format supported by a device (format, channels, sample rate, flags).
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_native_data_format
     {
+        /// <summary>
+        /// The sample format. If set to ma_format_unknown, all formats are supported.
+        /// </summary>
         public ma_uint32 format; // Assuming ma_format is a uint. Adjust as necessary.
+        /// <summary>
+        /// The number of channels. If set to 0, all channels are supported.
+        /// </summary>
         public ma_uint32 channels; // If set to 0, all channels are supported.
+        /// <summary>
+        /// The sample rate. If set to 0, all sample rates are supported.
+        /// </summary>
         public ma_uint32 sampleRate; // If set to 0, all sample rates are supported.
+        /// <summary>
+        /// A combination of MA_DATA_FORMAT_FLAG_* flags.
+        /// </summary>
         public ma_uint32 flags; // A combination of MA_DATA_FORMAT_FLAG_* flags.
     }
 
+    /// <summary>
+    /// Contains information about an audio device including its ID, name, and supported native data formats.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public unsafe struct ma_device_info
     {
         /* Basic info. This is the only information guaranteed to be filled in during device enumeration. */
+        /// <summary>
+        /// The unique device identifier.
+        /// </summary>
         public ma_device_id id;
+        /// <summary>
+        /// The device name (fixed-size UTF-8 buffer). Use GetName() to retrieve as a string.
+        /// </summary>
         public fixed byte name[MiniAudioNative.MA_MAX_DEVICE_NAME_LENGTH + 1];
+        /// <summary>
+        /// Whether this device is the system default device.
+        /// </summary>
         public ma_bool32 isDefault;
+        /// <summary>
+        /// The number of native data formats supported by this device.
+        /// </summary>
         public ma_uint32 nativeDataFormatCount;
+        /// <summary>
+        /// Array of native data formats supported by this device.
+        /// </summary>
         public ma_native_data_format_array nativeDataFormats;
 
+        /// <summary>
+        /// Gets the device name as a managed UTF-8 string.
+        /// </summary>
+        /// <returns>The device name, or an empty string if no name is set.</returns>
         public string GetName()
         {
             unsafe
@@ -920,73 +2055,273 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Fixed-size array of native data formats with an indexer for access.
+        /// </summary>
         [StructLayout(LayoutKind.Sequential)]
         public struct ma_native_data_format_array
         {
+            /// <summary>
+            /// Native data format slot 0.
+            /// </summary>
             public ma_native_data_format ndf0;
+            /// <summary>
+            /// Native data format slot 1.
+            /// </summary>
             public ma_native_data_format ndf1;
+            /// <summary>
+            /// Native data format slot 2.
+            /// </summary>
             public ma_native_data_format ndf2;
+            /// <summary>
+            /// Native data format slot 3.
+            /// </summary>
             public ma_native_data_format ndf3;
+            /// <summary>
+            /// Native data format slot 4.
+            /// </summary>
             public ma_native_data_format ndf4;
+            /// <summary>
+            /// Native data format slot 5.
+            /// </summary>
             public ma_native_data_format ndf5;
+            /// <summary>
+            /// Native data format slot 6.
+            /// </summary>
             public ma_native_data_format ndf6;
+            /// <summary>
+            /// Native data format slot 7.
+            /// </summary>
             public ma_native_data_format ndf7;
+            /// <summary>
+            /// Native data format slot 8.
+            /// </summary>
             public ma_native_data_format ndf8;
+            /// <summary>
+            /// Native data format slot 9.
+            /// </summary>
             public ma_native_data_format ndf9;
+            /// <summary>
+            /// Native data format slot 10.
+            /// </summary>
             public ma_native_data_format ndf10;
+            /// <summary>
+            /// Native data format slot 11.
+            /// </summary>
             public ma_native_data_format ndf11;
+            /// <summary>
+            /// Native data format slot 12.
+            /// </summary>
             public ma_native_data_format ndf12;
+            /// <summary>
+            /// Native data format slot 13.
+            /// </summary>
             public ma_native_data_format ndf13;
+            /// <summary>
+            /// Native data format slot 14.
+            /// </summary>
             public ma_native_data_format ndf14;
+            /// <summary>
+            /// Native data format slot 15.
+            /// </summary>
             public ma_native_data_format ndf15;
+            /// <summary>
+            /// Native data format slot 16.
+            /// </summary>
             public ma_native_data_format ndf16;
+            /// <summary>
+            /// Native data format slot 17.
+            /// </summary>
             public ma_native_data_format ndf17;
+            /// <summary>
+            /// Native data format slot 18.
+            /// </summary>
             public ma_native_data_format ndf18;
+            /// <summary>
+            /// Native data format slot 19.
+            /// </summary>
             public ma_native_data_format ndf19;
+            /// <summary>
+            /// Native data format slot 20.
+            /// </summary>
             public ma_native_data_format ndf20;
+            /// <summary>
+            /// Native data format slot 21.
+            /// </summary>
             public ma_native_data_format ndf21;
+            /// <summary>
+            /// Native data format slot 22.
+            /// </summary>
             public ma_native_data_format ndf22;
+            /// <summary>
+            /// Native data format slot 23.
+            /// </summary>
             public ma_native_data_format ndf23;
+            /// <summary>
+            /// Native data format slot 24.
+            /// </summary>
             public ma_native_data_format ndf24;
+            /// <summary>
+            /// Native data format slot 25.
+            /// </summary>
             public ma_native_data_format ndf25;
+            /// <summary>
+            /// Native data format slot 26.
+            /// </summary>
             public ma_native_data_format ndf26;
+            /// <summary>
+            /// Native data format slot 27.
+            /// </summary>
             public ma_native_data_format ndf27;
+            /// <summary>
+            /// Native data format slot 28.
+            /// </summary>
             public ma_native_data_format ndf28;
+            /// <summary>
+            /// Native data format slot 29.
+            /// </summary>
             public ma_native_data_format ndf29;
+            /// <summary>
+            /// Native data format slot 30.
+            /// </summary>
             public ma_native_data_format ndf30;
+            /// <summary>
+            /// Native data format slot 31.
+            /// </summary>
             public ma_native_data_format ndf31;
+            /// <summary>
+            /// Native data format slot 32.
+            /// </summary>
             public ma_native_data_format ndf32;
+            /// <summary>
+            /// Native data format slot 33.
+            /// </summary>
             public ma_native_data_format ndf33;
+            /// <summary>
+            /// Native data format slot 34.
+            /// </summary>
             public ma_native_data_format ndf34;
+            /// <summary>
+            /// Native data format slot 35.
+            /// </summary>
             public ma_native_data_format ndf35;
+            /// <summary>
+            /// Native data format slot 36.
+            /// </summary>
             public ma_native_data_format ndf36;
+            /// <summary>
+            /// Native data format slot 37.
+            /// </summary>
             public ma_native_data_format ndf37;
+            /// <summary>
+            /// Native data format slot 38.
+            /// </summary>
             public ma_native_data_format ndf38;
+            /// <summary>
+            /// Native data format slot 39.
+            /// </summary>
             public ma_native_data_format ndf39;
+            /// <summary>
+            /// Native data format slot 40.
+            /// </summary>
             public ma_native_data_format ndf40;
+            /// <summary>
+            /// Native data format slot 41.
+            /// </summary>
             public ma_native_data_format ndf41;
+            /// <summary>
+            /// Native data format slot 42.
+            /// </summary>
             public ma_native_data_format ndf42;
+            /// <summary>
+            /// Native data format slot 43.
+            /// </summary>
             public ma_native_data_format ndf43;
+            /// <summary>
+            /// Native data format slot 44.
+            /// </summary>
             public ma_native_data_format ndf44;
+            /// <summary>
+            /// Native data format slot 45.
+            /// </summary>
             public ma_native_data_format ndf45;
+            /// <summary>
+            /// Native data format slot 46.
+            /// </summary>
             public ma_native_data_format ndf46;
+            /// <summary>
+            /// Native data format slot 47.
+            /// </summary>
             public ma_native_data_format ndf47;
+            /// <summary>
+            /// Native data format slot 48.
+            /// </summary>
             public ma_native_data_format ndf48;
+            /// <summary>
+            /// Native data format slot 49.
+            /// </summary>
             public ma_native_data_format ndf49;
+            /// <summary>
+            /// Native data format slot 50.
+            /// </summary>
             public ma_native_data_format ndf50;
+            /// <summary>
+            /// Native data format slot 51.
+            /// </summary>
             public ma_native_data_format ndf51;
+            /// <summary>
+            /// Native data format slot 52.
+            /// </summary>
             public ma_native_data_format ndf52;
+            /// <summary>
+            /// Native data format slot 53.
+            /// </summary>
             public ma_native_data_format ndf53;
+            /// <summary>
+            /// Native data format slot 54.
+            /// </summary>
             public ma_native_data_format ndf54;
+            /// <summary>
+            /// Native data format slot 55.
+            /// </summary>
             public ma_native_data_format ndf55;
+            /// <summary>
+            /// Native data format slot 56.
+            /// </summary>
             public ma_native_data_format ndf56;
+            /// <summary>
+            /// Native data format slot 57.
+            /// </summary>
             public ma_native_data_format ndf57;
+            /// <summary>
+            /// Native data format slot 58.
+            /// </summary>
             public ma_native_data_format ndf58;
+            /// <summary>
+            /// Native data format slot 59.
+            /// </summary>
             public ma_native_data_format ndf59;
+            /// <summary>
+            /// Native data format slot 60.
+            /// </summary>
             public ma_native_data_format ndf60;
+            /// <summary>
+            /// Native data format slot 61.
+            /// </summary>
             public ma_native_data_format ndf61;
+            /// <summary>
+            /// Native data format slot 62.
+            /// </summary>
             public ma_native_data_format ndf62;
+            /// <summary>
+            /// Native data format slot 63.
+            /// </summary>
             public ma_native_data_format ndf63;
+            /// <summary>
+            /// Indexed access to the native data format array. Bounds-checked between 0 and 63.
+            /// </summary>
+            /// <param name="index">The index of the native data format to access.</param>
+            /// <returns>A reference to the native data format at the given index.</returns>
             public ref ma_native_data_format this[int index]
             {
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1005,295 +2340,841 @@ namespace MiniAudioEx.Native
         }
     }
 
+    /// <summary>
+    /// Configuration for a resampler. Specifies input/output formats, channel counts, sample rates, and algorithm.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_resampler_config
     {
+        /// <summary>
+        /// The sample format. Must be either ma_format_f32 or ma_format_s16.
+        /// </summary>
         public ma_format format;   /* Must be either ma_format_f32 or ma_format_s16. */
+        /// <summary>
+        /// The number of channels.
+        /// </summary>
         public ma_uint32 channels;
+        /// <summary>
+        /// The input sample rate.
+        /// </summary>
         public ma_uint32 sampleRateIn;
+        /// <summary>
+        /// The output sample rate.
+        /// </summary>
         public ma_uint32 sampleRateOut;
+        /// <summary>
+        /// The resampling algorithm. When set to ma_resample_algorithm_custom, pBackendVTable will be used.
+        /// </summary>
         public ma_resample_algorithm algorithm;    /* When set to ma_resample_algorithm_custom, pBackendVTable will be used. */
+        /// <summary>
+        /// Pointer to a custom backend vtable for resampling.
+        /// </summary>
         public ma_resampling_backend_vtable_ptr pBackendVTable;
+        /// <summary>
+        /// User data for the custom resampling backend.
+        /// </summary>
         public IntPtr pBackendUserData;
+        /// <summary>
+        /// Linear resampler specific configuration.
+        /// </summary>
         public linear_info linear;
+        /// <summary>
+        /// Linear resampler specific info controlling the low-pass filter order.
+        /// </summary>
         [StructLayout(LayoutKind.Sequential)]
         public struct linear_info
         {
+            /// <summary>
+            /// The low-pass filter order for the linear resampler.
+            /// </summary>
             public ma_uint32 lpfOrder;
         }
     }
 
+    /// <summary>
+    /// Configuration for an audio device. Specifies device type, format, period size, callbacks, and backend-specific options.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_device_config
     {
+        /// <summary>
+        /// The type of device (playback, capture, duplex, or loopback).
+        /// </summary>
         public ma_device_type deviceType;
+        /// <summary>
+        /// The requested sample rate.
+        /// </summary>
         public ma_uint32 sampleRate;
+        /// <summary>
+        /// The requested period size in frames.
+        /// </summary>
         public ma_uint32 periodSizeInFrames;
+        /// <summary>
+        /// The requested period size in milliseconds.
+        /// </summary>
         public ma_uint32 periodSizeInMilliseconds;
+        /// <summary>
+        /// The number of periods.
+        /// </summary>
         public ma_uint32 periods;
+        /// <summary>
+        /// The performance profile for the device.
+        /// </summary>
         public ma_performance_profile performanceProfile;
+        /// <summary>
+        /// When set to true, the contents of the output buffer passed into the data callback will be left undefined rather than initialized to silence.
+        /// </summary>
         public ma_bool8 noPreSilencedOutputBuffer; /* When set to true, the contents of the output buffer passed into the data callback will be left undefined rather than initialized to silence. */
+        /// <summary>
+        /// When set to true, the contents of the output buffer passed into the data callback will not be clipped after returning. Only applies when the playback sample format is f32.
+        /// </summary>
         public ma_bool8 noClip;                    /* When set to true, the contents of the output buffer passed into the data callback will not be clipped after returning. Only applies when the playback sample format is f32. */
+        /// <summary>
+        /// Do not disable denormals when firing the data callback.
+        /// </summary>
         public ma_bool8 noDisableDenormals;        /* Do not disable denormals when firing the data callback. */
+        /// <summary>
+        /// Disables strict fixed-sized data callbacks. Setting this to true will result in the period size being treated only as a hint to the backend.
+        /// </summary>
         public ma_bool8 noFixedSizedCallback;      /* Disables strict fixed-sized data callbacks. Setting this to true will result in the period size being treated only as a hint to the backend. This is an optimization for those who don't need fixed sized callbacks. */
+        /// <summary>
+        /// Function pointer to the data callback.
+        /// </summary>
         public IntPtr dataCallback;
+        /// <summary>
+        /// Function pointer to the notification callback.
+        /// </summary>
         public IntPtr notificationCallback;
+        /// <summary>
+        /// Function pointer to the stop callback (DEPRECATED, use notification callback instead).
+        /// </summary>
         public IntPtr stopCallback;
+        /// <summary>
+        /// Application-defined user data.
+        /// </summary>
         public IntPtr pUserData;
+        /// <summary>
+        /// Resampling configuration.
+        /// </summary>
         public ma_resampler_config resampling;
+        /// <summary>
+        /// Playback-specific configuration.
+        /// </summary>
         public playback_info playback;
+        /// <summary>
+        /// Capture-specific configuration.
+        /// </summary>
         public capture_info capture;
+        /// <summary>
+        /// WASAPI-specific configuration.
+        /// </summary>
         public wasapi_info wasapi;
+        /// <summary>
+        /// ALSA-specific configuration.
+        /// </summary>
         public alsa_info alsa;
+        /// <summary>
+        /// PulseAudio-specific configuration.
+        /// </summary>
         public pulse_info pulse;
+        /// <summary>
+        /// Core Audio-specific configuration.
+        /// </summary>
         public coreaudio_info coreaudio;
+        /// <summary>
+        /// OpenSL|ES-specific configuration.
+        /// </summary>
         public opensl_info opensl;
+        /// <summary>
+        /// AAudio-specific configuration.
+        /// </summary>
         public aaudio_info aaudio;
 
+        /// <summary>
+        /// Playback sub-configuration specifying the playback device, format, channels, and channel mix mode.
+        /// </summary>
         [StructLayout(LayoutKind.Sequential)]
         public struct playback_info
         {
+            /// <summary>
+            /// Pointer to the device ID. Set to null for default device.
+            /// </summary>
             public ma_device_id_ptr pDeviceID;
+            /// <summary>
+            /// The playback sample format.
+            /// </summary>
             public ma_format format;
+            /// <summary>
+            /// The number of playback channels.
+            /// </summary>
             public ma_uint32 channels;
+            /// <summary>
+            /// Pointer to the channel map for the playback device.
+            /// </summary>
             public ma_channel_ptr pChannelMap;
+            /// <summary>
+            /// The channel mix mode for the playback device.
+            /// </summary>
             public ma_channel_mix_mode channelMixMode;
+            /// <summary>
+            /// When an output LFE channel is present, but no input LFE, set to true to set the output LFE to the average of all spatial channels.
+            /// </summary>
             public ma_bool32 calculateLFEFromSpatialChannels;  /* When an output LFE channel is present, but no input LFE, set to true to set the output LFE to the average of all spatial channels (LR, FR, etc.). Ignored when an input LFE is present. */
+            /// <summary>
+            /// The share mode for the playback device.
+            /// </summary>
             public ma_share_mode shareMode;
         }
 
+        /// <summary>
+        /// Capture sub-configuration specifying the capture device, format, channels, and channel mix mode.
+        /// </summary>
         [StructLayout(LayoutKind.Sequential)]
         public struct capture_info
         {
+            /// <summary>
+            /// Pointer to the device ID. Set to null for default device.
+            /// </summary>
             public ma_device_id_ptr pDeviceID;
+            /// <summary>
+            /// The capture sample format.
+            /// </summary>
             public ma_format format;
+            /// <summary>
+            /// The number of capture channels.
+            /// </summary>
             public ma_uint32 channels;
+            /// <summary>
+            /// Pointer to the channel map for the capture device.
+            /// </summary>
             public ma_channel_ptr pChannelMap;
+            /// <summary>
+            /// The channel mix mode for the capture device.
+            /// </summary>
             public ma_channel_mix_mode channelMixMode;
+            /// <summary>
+            /// When an output LFE channel is present, but no input LFE, set to true to set the output LFE to the average of all spatial channels.
+            /// </summary>
             public ma_bool32 calculateLFEFromSpatialChannels;  /* When an output LFE channel is present, but no input LFE, set to true to set the output LFE to the average of all spatial channels (LR, FR, etc.). Ignored when an input LFE is present. */
+            /// <summary>
+            /// The share mode for the capture device.
+            /// </summary>
             public ma_share_mode shareMode;
         }
 
+        /// <summary>
+        /// WASAPI-specific device configuration.
+        /// </summary>
         [StructLayout(LayoutKind.Sequential)]
         public struct wasapi_info
         {
+            /// <summary>
+            /// When configured, uses Avrt APIs to set the thread characteristics.
+            /// </summary>
             public ma_wasapi_usage usage;              /* When configured, uses Avrt APIs to set the thread characteristics. */
+            /// <summary>
+            /// When set to true, disables the use of AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM.
+            /// </summary>
             public ma_bool8 noAutoConvertSRC;          /* When set to true, disables the use of AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM. */
+            /// <summary>
+            /// When set to true, disables the use of AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY.
+            /// </summary>
             public ma_bool8 noDefaultQualitySRC;       /* When set to true, disables the use of AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY. */
+            /// <summary>
+            /// Disables automatic stream routing.
+            /// </summary>
             public ma_bool8 noAutoStreamRouting;       /* Disables automatic stream routing. */
+            /// <summary>
+            /// Disables WASAPI's hardware offloading feature.
+            /// </summary>
             public ma_bool8 noHardwareOffloading;      /* Disables WASAPI's hardware offloading feature. */
+            /// <summary>
+            /// The process ID to include or exclude for loopback mode. Set to 0 to capture audio from all processes.
+            /// </summary>
             public ma_uint32 loopbackProcessID;        /* The process ID to include or exclude for loopback mode. Set to 0 to capture audio from all processes. Ignored when an explicit device ID is specified. */
+            /// <summary>
+            /// When set to true, excludes the process specified by loopbackProcessID. By default, the process will be included.
+            /// </summary>
             public ma_bool8 loopbackProcessExclude;    /* When set to true, excludes the process specified by loopbackProcessID. By default, the process will be included. */
         }
 
+        /// <summary>
+        /// ALSA-specific device configuration.
+        /// </summary>
         [StructLayout(LayoutKind.Sequential)]
         public struct alsa_info
         {
+            /// <summary>
+            /// Disables MMap mode.
+            /// </summary>
             public ma_bool32 noMMap;           /* Disables MMap mode. */
+            /// <summary>
+            /// Opens the ALSA device with SND_PCM_NO_AUTO_FORMAT.
+            /// </summary>
             public ma_bool32 noAutoFormat;     /* Opens the ALSA device with SND_PCM_NO_AUTO_FORMAT. */
+            /// <summary>
+            /// Opens the ALSA device with SND_PCM_NO_AUTO_CHANNELS.
+            /// </summary>
             public ma_bool32 noAutoChannels;   /* Opens the ALSA device with SND_PCM_NO_AUTO_CHANNELS. */
+            /// <summary>
+            /// Opens the ALSA device with SND_PCM_NO_AUTO_RESAMPLE.
+            /// </summary>
             public ma_bool32 noAutoResample;   /* Opens the ALSA device with SND_PCM_NO_AUTO_RESAMPLE. */
         }
 
+        /// <summary>
+        /// PulseAudio-specific device configuration.
+        /// </summary>
         [StructLayout(LayoutKind.Sequential)]
         public struct pulse_info
         {
+            /// <summary>
+            /// The stream name for playback.
+            /// </summary>
             public IntPtr pStreamNamePlayback;
+            /// <summary>
+            /// The stream name for capture.
+            /// </summary>
             public IntPtr pStreamNameCapture;
+            /// <summary>
+            /// The channel map for PulseAudio.
+            /// </summary>
             public int channelMap;
         }
 
+        /// <summary>
+        /// Core Audio-specific device configuration (macOS).
+        /// </summary>
         [StructLayout(LayoutKind.Sequential)]
         public struct coreaudio_info
         {
+            /// <summary>
+            /// Desktop only. When enabled, allows changing of the sample rate at the operating system level.
+            /// </summary>
             public ma_bool32 allowNominalSampleRateChange; /* Desktop only. When enabled, allows changing of the sample rate at the operating system level. */
         }
 
+        /// <summary>
+        /// OpenSL|ES-specific device configuration (Android).
+        /// </summary>
         [StructLayout(LayoutKind.Sequential)]
         public struct opensl_info
         {
+            /// <summary>
+            /// The OpenSL|ES stream type.
+            /// </summary>
             public ma_opensl_stream_type streamType;
+            /// <summary>
+            /// The OpenSL|ES recording preset.
+            /// </summary>
             public ma_opensl_recording_preset recordingPreset;
+            /// <summary>
+            /// Enables compatibility workarounds for OpenSL|ES.
+            /// </summary>
             public ma_bool32 enableCompatibilityWorkarounds;
         }
 
+        /// <summary>
+        /// AAudio-specific device configuration (Android).
+        /// </summary>
         [StructLayout(LayoutKind.Sequential)]
         public struct aaudio_info
         {
+            /// <summary>
+            /// The AAudio usage hint.
+            /// </summary>
             public ma_aaudio_usage usage;
+            /// <summary>
+            /// The AAudio content type.
+            /// </summary>
             public ma_aaudio_content_type contentType;
+            /// <summary>
+            /// The AAudio input preset.
+            /// </summary>
             public ma_aaudio_input_preset inputPreset;
+            /// <summary>
+            /// The AAudio allowed capture policy.
+            /// </summary>
             public ma_aaudio_allowed_capture_policy allowedCapturePolicy;
+            /// <summary>
+            /// When set to true, does not auto-start the stream after a reroute.
+            /// </summary>
             public ma_bool32 noAutoStartAfterReroute;
+            /// <summary>
+            /// Enables compatibility workarounds for AAudio.
+            /// </summary>
             public ma_bool32 enableCompatibilityWorkarounds;
+            /// <summary>
+            /// When set to true, allows setting the buffer capacity.
+            /// </summary>
             public ma_bool32 allowSetBufferCapacity;
         }
 
+        /// <summary>
+        /// Sets the data callback for the device.
+        /// </summary>
+        /// <param name="dataCallback">The data callback delegate.</param>
         public void SetDataCallback(ma_device_data_proc dataCallback)
         {
             this.dataCallback = MarshalHelper.GetFunctionPointerForDelegate(dataCallback);
         }
 
+        /// <summary>
+        /// Sets the notification callback for the device.
+        /// </summary>
+        /// <param name="notificationCallback">The notification callback delegate.</param>
         public void SetNotificationCallback(ma_device_notification_proc notificationCallback)
         {
             this.notificationCallback = MarshalHelper.GetFunctionPointerForDelegate(notificationCallback);
         }
 
+        /// <summary>
+        /// Sets the stop callback for the device (DEPRECATED).
+        /// </summary>
+        /// <param name="stopCallback">The stop callback delegate.</param>
         public void SetStopCallback(ma_stop_proc stopCallback)
         {
             this.stopCallback = MarshalHelper.GetFunctionPointerForDelegate(stopCallback);
         }
     }
 
+    /// <summary>
+    /// A union structure representing the device ID across different backends (WASAPI, DirectSound, ALSA, PulseAudio, JACK, CoreAudio, etc.).
+    /// </summary>
     [StructLayout(LayoutKind.Explicit, Size = 256)] // largest member size determines union size
     public unsafe struct ma_device_id
     {
+        /// <summary>
+        /// WASAPI device identifier (wide-char array).
+        /// </summary>
         [FieldOffset(0)]
         public fixed ma_uint16 wasapi[64];
+        /// <summary>
+        /// DirectSound device identifier (GUID).
+        /// </summary>
         [FieldOffset(0)]
         public fixed byte dsound[16];
+        /// <summary>
+        /// WinMM device identifier (integer).
+        /// </summary>
         [FieldOffset(0)]
         public ma_uint32 winmm;
+        /// <summary>
+        /// ALSA device identifier (string).
+        /// </summary>
         [FieldOffset(0)]
         public fixed byte alsa[256];
+        /// <summary>
+        /// PulseAudio device identifier (string).
+        /// </summary>
         [FieldOffset(0)]
         public fixed byte pulse[256];
+        /// <summary>
+        /// JACK device identifier (integer).
+        /// </summary>
         [FieldOffset(0)]
         public int jack;
+        /// <summary>
+        /// Core Audio device identifier (string).
+        /// </summary>
         [FieldOffset(0)]
         public fixed byte coreaudio[256];
+        /// <summary>
+        /// sndio device identifier (string).
+        /// </summary>
         [FieldOffset(0)]
         public fixed byte sndio[256];
+        /// <summary>
+        /// Audio4 device identifier (string).
+        /// </summary>
         [FieldOffset(0)]
         public fixed byte audio4[256];
+        /// <summary>
+        /// OSS device identifier (string).
+        /// </summary>
         [FieldOffset(0)]
         public fixed byte oss[64];
+        /// <summary>
+        /// AAudio device identifier (integer).
+        /// </summary>
         [FieldOffset(0)]
         public int aaudio;
+        /// <summary>
+        /// OpenSL|ES device identifier (unsigned integer).
+        /// </summary>
         [FieldOffset(0)]
         public uint opensl;
+        /// <summary>
+        /// Web Audio device identifier (string).
+        /// </summary>
         [FieldOffset(0)]
         public fixed byte webaudio[32];
+        /// <summary>
+        /// Custom backend device identifier (integer).
+        /// </summary>
         [FieldOffset(0)]
         public int custom_i;
+        /// <summary>
+        /// Custom backend device identifier (string).
+        /// </summary>
         [FieldOffset(0)]
         public fixed byte custom_s[256];
+        /// <summary>
+        /// Custom backend device identifier (pointer).
+        /// </summary>
         [FieldOffset(0)]
         public IntPtr custom_p;
+        /// <summary>
+        /// Null backend device identifier (integer).
+        /// </summary>
         [FieldOffset(0)]
         public int nullbackend;
     }
 
+    /// <summary>
+    /// Configuration for device-side resampling.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_device_resampling
     {
+        /// <summary>
+        /// The resampling algorithm to use.
+        /// </summary>
         public ma_resample_algorithm algorithm;
+        /// <summary>
+        /// Pointer to a custom backend vtable for resampling.
+        /// </summary>
         public ma_resampling_backend_vtable_ptr pBackendVTable;
+        /// <summary>
+        /// User data for the custom resampling backend.
+        /// </summary>
         public IntPtr pBackendUserData;
+        /// <summary>
+        /// Linear resampler specific configuration.
+        /// </summary>
         public ma_device_lpf_order linear;
+        /// <summary>
+        /// Low-pass filter order for the device's linear resampler.
+        /// </summary>
         [StructLayout(LayoutKind.Sequential)]
         public struct ma_device_lpf_order
         {
+            /// <summary>
+            /// The low-pass filter order.
+            /// </summary>
             ma_uint32 lpfOrder;
         }
     }
 
+    /// <summary>
+    /// Runtime state for the playback side of a device.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public unsafe struct ma_device_playback
     {
+        /// <summary>
+        /// Set to NULL if using default ID, otherwise set to the address of the id field.
+        /// </summary>
         public ma_device_id_ptr pID;                  /* Set to NULL if using default ID, otherwise set to the address of "id". */
+        /// <summary>
+        /// If using an explicit device, will be set to a copy of the ID used for initialization. Otherwise cleared to 0.
+        /// </summary>
         public ma_device_id id;                    /* If using an explicit device, will be set to a copy of the ID used for initialization. Otherwise cleared to 0. */
+        /// <summary>
+        /// The device name (fixed-size buffer). Maybe temporary; likely to be replaced with a query API.
+        /// </summary>
         public fixed byte name[MiniAudioNative.MA_MAX_DEVICE_NAME_LENGTH + 1]; /* Maybe temporary. Likely to be replaced with a query API. */
+        /// <summary>
+        /// The share mode used when the device was initialized.
+        /// </summary>
         public ma_share_mode shareMode;            /* Set to whatever was passed in when the device was initialized. */
+        /// <summary>
+        /// The external playback format.
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The external playback channel count.
+        /// </summary>
         public ma_uint32 channels;
+        /// <summary>
+        /// The external playback channel map.
+        /// </summary>
         public fixed ma_channel channelMap[MiniAudioNative.MA_MAX_CHANNELS];
+        /// <summary>
+        /// The internal format used by the backend.
+        /// </summary>
         public ma_format internalFormat;
+        /// <summary>
+        /// The internal channel count used by the backend.
+        /// </summary>
         public ma_uint32 internalChannels;
+        /// <summary>
+        /// The internal sample rate used by the backend.
+        /// </summary>
         public ma_uint32 internalSampleRate;
+        /// <summary>
+        /// The internal channel map used by the backend.
+        /// </summary>
         public fixed ma_channel internalChannelMap[MiniAudioNative.MA_MAX_CHANNELS];
+        /// <summary>
+        /// The internal period size in frames.
+        /// </summary>
         public ma_uint32 internalPeriodSizeInFrames;
+        /// <summary>
+        /// The internal number of periods.
+        /// </summary>
         public ma_uint32 internalPeriods;
+        /// <summary>
+        /// The channel mix mode for playback.
+        /// </summary>
         public ma_channel_mix_mode channelMixMode;
+        /// <summary>
+        /// Whether to calculate LFE from spatial channels when an output LFE is present but no input LFE.
+        /// </summary>
         public ma_bool32 calculateLFEFromSpatialChannels;
+        /// <summary>
+        /// The data converter for format/channel conversion.
+        /// </summary>
         public ma_data_converter converter;
+        /// <summary>
+        /// Intermediary buffer for implementing fixed sized buffer callbacks. Will be null if using variable sized callbacks.
+        /// </summary>
         public IntPtr pIntermediaryBuffer;          /* For implementing fixed sized buffer callbacks. Will be null if using variable sized callbacks. */
+        /// <summary>
+        /// Capacity of the intermediary buffer.
+        /// </summary>
         public ma_uint32 intermediaryBufferCap;
+        /// <summary>
+        /// Number of valid frames sitting in the intermediary buffer.
+        /// </summary>
         public ma_uint32 intermediaryBufferLen;    /* How many valid frames are sitting in the intermediary buffer. */
+        /// <summary>
+        /// Input cache buffer in external format. Can be null.
+        /// </summary>
         public IntPtr pInputCache;                  /* In external format. Can be null. */
+        /// <summary>
+        /// Capacity of the input cache.
+        /// </summary>
         public ma_uint64 inputCacheCap;
+        /// <summary>
+        /// Number of frames consumed from the input cache.
+        /// </summary>
         public ma_uint64 inputCacheConsumed;
+        /// <summary>
+        /// Number of valid frames remaining in the input cache.
+        /// </summary>
         public ma_uint64 inputCacheRemaining;
     }
 
+    /// <summary>
+    /// Runtime state for the capture side of a device.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public unsafe struct ma_device_capture
     {
+        /// <summary>
+        /// Set to NULL if using default ID, otherwise set to the address of the id field.
+        /// </summary>
         public ma_device_id_ptr pID;                  /* Set to NULL if using default ID, otherwise set to the address of "id". */
+        /// <summary>
+        /// If using an explicit device, will be set to a copy of the ID used for initialization. Otherwise cleared to 0.
+        /// </summary>
         public ma_device_id id;                    /* If using an explicit device, will be set to a copy of the ID used for initialization. Otherwise cleared to 0. */
+        /// <summary>
+        /// The device name (fixed-size buffer). Maybe temporary; likely to be replaced with a query API.
+        /// </summary>
         public fixed byte name[MiniAudioNative.MA_MAX_DEVICE_NAME_LENGTH + 1];                     /* Maybe temporary. Likely to be replaced with a query API. */
+        /// <summary>
+        /// The share mode used when the device was initialized.
+        /// </summary>
         public ma_share_mode shareMode;            /* Set to whatever was passed in when the device was initialized. */
+        /// <summary>
+        /// The external capture format.
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The external capture channel count.
+        /// </summary>
         public ma_uint32 channels;
+        /// <summary>
+        /// The external capture channel map.
+        /// </summary>
         public fixed ma_channel channelMap[MiniAudioNative.MA_MAX_CHANNELS];
+        /// <summary>
+        /// The internal format used by the backend.
+        /// </summary>
         public ma_format internalFormat;
+        /// <summary>
+        /// The internal channel count used by the backend.
+        /// </summary>
         public ma_uint32 internalChannels;
+        /// <summary>
+        /// The internal sample rate used by the backend.
+        /// </summary>
         public ma_uint32 internalSampleRate;
+        /// <summary>
+        /// The internal channel map used by the backend.
+        /// </summary>
         public fixed ma_channel internalChannelMap[MiniAudioNative.MA_MAX_CHANNELS];
+        /// <summary>
+        /// The internal period size in frames.
+        /// </summary>
         public ma_uint32 internalPeriodSizeInFrames;
+        /// <summary>
+        /// The internal number of periods.
+        /// </summary>
         public ma_uint32 internalPeriods;
+        /// <summary>
+        /// The channel mix mode for capture.
+        /// </summary>
         public ma_channel_mix_mode channelMixMode;
+        /// <summary>
+        /// Whether to calculate LFE from spatial channels when an output LFE is present but no input LFE.
+        /// </summary>
         public ma_bool32 calculateLFEFromSpatialChannels;
+        /// <summary>
+        /// The data converter for format/channel conversion.
+        /// </summary>
         public ma_data_converter converter;
+        /// <summary>
+        /// Intermediary buffer for implementing fixed sized buffer callbacks. Will be null if using variable sized callbacks.
+        /// </summary>
         public IntPtr pIntermediaryBuffer;          /* For implementing fixed sized buffer callbacks. Will be null if using variable sized callbacks. */
+        /// <summary>
+        /// Capacity of the intermediary buffer.
+        /// </summary>
         public ma_uint32 intermediaryBufferCap;
+        /// <summary>
+        /// Number of valid frames sitting in the intermediary buffer.
+        /// </summary>
         public ma_uint32 intermediaryBufferLen;    /* How many valid frames are sitting in the intermediary buffer. */
     }
 
+    /// <summary>
+    /// Represents an audio device at runtime. Contains pointers to callbacks, context, and device state.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_device
     {
+        /// <summary>
+        /// Pointer to the parent context.
+        /// </summary>
         public ma_context_ptr pContext;
+        /// <summary>
+        /// The type of device (playback, capture, duplex, or loopback).
+        /// </summary>
         public ma_device_type type;
+        /// <summary>
+        /// The device sample rate.
+        /// </summary>
         public ma_uint32 sampleRate;
+        /// <summary>
+        /// The state of the device. Variable and can change at any time on any thread; must be used atomically.
+        /// </summary>
         public ma_device_state state;                      /* The state of the device is variable and can change at any time on any thread. Must be used atomically. */
+        /// <summary>
+        /// Function pointer to the data callback. Set once at initialization time and should not be changed after.
+        /// </summary>
         public IntPtr onData;                 /* Set once at initialization time and should not be changed after. */
+        /// <summary>
+        /// Function pointer to the notification callback. Set once at initialization time and should not be changed after.
+        /// </summary>
         public IntPtr onNotification; /* Set once at initialization time and should not be changed after. */
+        /// <summary>
+        /// DEPRECATED. Use the notification callback instead. Set once at initialization time and should not be changed after.
+        /// </summary>
         public IntPtr onStop;                        /* DEPRECATED. Use the notification callback instead. Set once at initialization time and should not be changed after. */
+        /// <summary>
+        /// Application-defined user data.
+        /// </summary>
         public IntPtr pUserData;                            /* Application defined data. */
         //There are a lot more fields down here but they are not needed as long other ma_types only use a pointer to ma_device
 
+        /// <summary>
+        /// Sets the data callback for the device.
+        /// </summary>
+        /// <param name="onData">The data callback delegate.</param>
         public void SetDataProc(ma_device_data_proc onData)
         {
             this.onData = MarshalHelper.GetFunctionPointerForDelegate(onData);
         }
 
+        /// <summary>
+        /// Sets the notification callback for the device.
+        /// </summary>
+        /// <param name="onNotification">The notification callback delegate.</param>
         public void SetNotificationProc(ma_device_notification_proc onNotification)
         {
             this.onNotification = MarshalHelper.GetFunctionPointerForDelegate(onNotification);
         }
 
+        /// <summary>
+        /// Sets the stop callback for the device (DEPRECATED).
+        /// </summary>
+        /// <param name="onStop">The stop callback delegate.</param>
         public void SetStopProc(ma_stop_proc onStop)
         {
             this.onStop = MarshalHelper.GetFunctionPointerForDelegate(onStop);
         }
     }
 
+    /// <summary>
+    /// Configuration for a decoder. Specifies output format, channel count, sample rate, encoding format, and custom backends.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_decoder_config
     {
+        /// <summary>
+        /// The output sample format. Set to 0 or ma_format_unknown to use the stream's internal format.
+        /// </summary>
         public ma_format format;      /* Set to 0 or ma_format_unknown to use the stream's internal format. */
+        /// <summary>
+        /// The output channel count. Set to 0 to use the stream's internal channels.
+        /// </summary>
         public ma_uint32 channels;    /* Set to 0 to use the stream's internal channels. */
+        /// <summary>
+        /// The output sample rate. Set to 0 to use the stream's internal sample rate.
+        /// </summary>
         public ma_uint32 sampleRate;  /* Set to 0 to use the stream's internal sample rate. */
+        /// <summary>
+        /// Pointer to the channel map for the output.
+        /// </summary>
         public ma_channel_ptr pChannelMap;
+        /// <summary>
+        /// The channel mix mode to use when converting channels.
+        /// </summary>
         public ma_channel_mix_mode channelMixMode;
+        /// <summary>
+        /// The dither mode to use for format conversion.
+        /// </summary>
         public ma_dither_mode ditherMode;
+        /// <summary>
+        /// Resampling configuration.
+        /// </summary>
         public ma_resampler_config resampling;
+        /// <summary>
+        /// Allocation callbacks used for memory management.
+        /// </summary>
         public ma_allocation_callbacks allocationCallbacks;
+        /// <summary>
+        /// The encoding format of the input data.
+        /// </summary>
         public ma_encoding_format encodingFormat;
+        /// <summary>
+        /// When set to > 0, specifies the number of seek points to use for the generation of a seek table. Not all decoding backends support this.
+        /// </summary>
         public ma_uint32 seekPointCount;   /* When set to > 0, specifies the number of seek points to use for the generation of a seek table. Not all decoding backends support this. */
+        /// <summary>
+        /// Pointer to an array of custom decoding backend vtable pointers.
+        /// </summary>
         public IntPtr ppCustomBackendVTables;
+        /// <summary>
+        /// The number of custom decoding backend vtables.
+        /// </summary>
         public ma_uint32 customBackendCount;
+        /// <summary>
+        /// User data passed to custom decoding backends.
+        /// </summary>
         public IntPtr pCustomBackendUserData;
 
         /// <summary>
@@ -1343,791 +3224,2067 @@ namespace MiniAudioEx.Native
         }
     }
 
+    /// <summary>
+    /// Represents a decoder at runtime. Reads audio data from a backend, with support for reading, seeking, and format conversion.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_decoder
     {
+        /// <summary>
+        /// The base data source.
+        /// </summary>
         public ma_data_source_base ds;
+        /// <summary>
+        /// The decoding backend from which data is pulled.
+        /// </summary>
         public ma_data_source_ptr pBackend;                   /* The decoding backend we'll be pulling data from. */
+        /// <summary>
+        /// The vtable for the decoding backend. Stored so we can access the onUninit() callback.
+        /// </summary>
         public IntPtr pBackendVTable; /* The vtable for the decoding backend. This needs to be stored so we can access the onUninit() callback. */
+        /// <summary>
+        /// User data passed to the decoding backend.
+        /// </summary>
         public IntPtr pBackendUserData;
+        /// <summary>
+        /// Function pointer to the custom read callback.
+        /// </summary>
         public IntPtr onRead;
+        /// <summary>
+        /// Function pointer to the custom seek callback.
+        /// </summary>
         public IntPtr onSeek;
+        /// <summary>
+        /// Function pointer to the custom tell callback.
+        /// </summary>
         public IntPtr onTell;
+        /// <summary>
+        /// User data for custom read/seek/tell callbacks.
+        /// </summary>
         public IntPtr pUserData;
+        /// <summary>
+        /// The read pointer in output sample rate PCM frames. Used for keeping track of how many frames are available for decoding.
+        /// </summary>
         public ma_uint64 readPointerInPCMFrames;      /* In output sample rate. Used for keeping track of how many frames are available for decoding. */
+        /// <summary>
+        /// The output sample format.
+        /// </summary>
         public ma_format outputFormat;
+        /// <summary>
+        /// The output channel count.
+        /// </summary>
         public ma_uint32 outputChannels;
+        /// <summary>
+        /// The output sample rate.
+        /// </summary>
         public ma_uint32 outputSampleRate;
+        /// <summary>
+        /// Data converter for converting frames from the backend format to the output format.
+        /// </summary>
         public ma_data_converter converter;    /* Data conversion is achieved by running frames through this. */
+        /// <summary>
+        /// Input cache buffer in input format. Can be null if it is not needed.
+        /// </summary>
         public IntPtr pInputCache;              /* In input format. Can be null if it's not needed. */
+        /// <summary>
+        /// The capacity of the input cache.
+        /// </summary>
         public ma_uint64 inputCacheCap;        /* The capacity of the input cache. */
+        /// <summary>
+        /// The number of frames that have been consumed in the cache.
+        /// </summary>
         public ma_uint64 inputCacheConsumed;   /* The number of frames that have been consumed in the cache. Used for determining the next valid frame. */
+        /// <summary>
+        /// The number of valid frames remaining in the cache.
+        /// </summary>
         public ma_uint64 inputCacheRemaining;  /* The number of valid frames remaining in the cache. */
+        /// <summary>
+        /// Allocation callbacks used for memory management.
+        /// </summary>
         public ma_allocation_callbacks allocationCallbacks;
+        /// <summary>
+        /// The decoder data (either VFS file or memory buffer).
+        /// </summary>
         public ma_decoder_data_union data;
 
+        /// <summary>
+        /// Sets the custom read callback for the decoder.
+        /// </summary>
+        /// <param name="callback">The read callback delegate.</param>
         public void SetReadProc(ma_decoder_read_proc callback)
         {
             onRead = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
+        /// <summary>
+        /// Sets the custom seek callback for the decoder.
+        /// </summary>
+        /// <param name="callback">The seek callback delegate.</param>
         public void SetSeekProc(ma_decoder_seek_proc callback)
         {
             onSeek = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
+        /// <summary>
+        /// Sets the custom tell callback for the decoder.
+        /// </summary>
+        /// <param name="callback">The tell callback delegate.</param>
         public void SetTellProc(ma_decoder_tell_proc callback)
         {
             onTell = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
 
+        /// <summary>
+        /// VFS-based decoder data (file opened via virtual file system).
+        /// </summary>
         [StructLayout(LayoutKind.Sequential)]
         public struct ma_decoder_data_vfs
         {
+            /// <summary>
+            /// Pointer to the virtual file system.
+            /// </summary>
             public ma_vfs_ptr pVFS;
+            /// <summary>
+            /// The VFS file handle.
+            /// </summary>
             public ma_vfs_file file;
         }
 
+        /// <summary>
+        /// Memory-based decoder data (raw memory buffer).
+        /// </summary>
         [StructLayout(LayoutKind.Sequential)]
         public struct ma_decoder_data_memory
         {
+            /// <summary>
+            /// Pointer to the raw memory buffer.
+            /// </summary>
             public IntPtr pData; // const ma_uint8*
+            /// <summary>
+            /// The size of the data in bytes.
+            /// </summary>
             public size_t dataSize;
+            /// <summary>
+            /// The current read position in bytes.
+            /// </summary>
             public size_t currentReadPos;
         }
 
+        /// <summary>
+        /// Union of VFS and memory-based decoder data.
+        /// </summary>
         [StructLayout(LayoutKind.Explicit)]
         public struct ma_decoder_data_union
         {
+            /// <summary>
+            /// VFS-based data.
+            /// </summary>
             [FieldOffset(0)]
             public ma_decoder_data_vfs vfs;
 
+            /// <summary>
+            /// Memory-based data.
+            /// </summary>
             [FieldOffset(0)]
             public ma_decoder_data_memory memory;
         }
     }
 
+    /// <summary>
+    /// Configuration for an encoder. Specifies the encoding format, output format, channel count, and sample rate.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_encoder_config
     {
+        /// <summary>
+        /// The encoding format (WAV, FLAC, etc.).
+        /// </summary>
         public ma_encoding_format encodingFormat;
+        /// <summary>
+        /// The output sample format.
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The output channel count.
+        /// </summary>
         public ma_uint32 channels;
+        /// <summary>
+        /// The output sample rate.
+        /// </summary>
         public ma_uint32 sampleRate;
+        /// <summary>
+        /// Allocation callbacks used for memory management.
+        /// </summary>
         public ma_allocation_callbacks allocationCallbacks;
     }
 
+    /// <summary>
+    /// Represents an encoder at runtime. Encodes PCM audio data to a specified format with custom write/seek/init callbacks.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_encoder
     {
+        /// <summary>
+        /// The encoder configuration.
+        /// </summary>
         public ma_encoder_config config;
+        /// <summary>
+        /// Function pointer to the custom write callback.
+        /// </summary>
         public IntPtr onWrite;
+        /// <summary>
+        /// Function pointer to the custom seek callback.
+        /// </summary>
         public IntPtr onSeek;
+        /// <summary>
+        /// Function pointer to the custom init callback.
+        /// </summary>
         public IntPtr onInit;
+        /// <summary>
+        /// Function pointer to the custom uninit callback.
+        /// </summary>
         public IntPtr onUninit;
+        /// <summary>
+        /// Function pointer to the custom write PCM frames callback.
+        /// </summary>
         public IntPtr onWritePCMFrames;
+        /// <summary>
+        /// Application-defined user data.
+        /// </summary>
         public IntPtr pUserData;
+        /// <summary>
+        /// Pointer to the internal encoder implementation.
+        /// </summary>
         public IntPtr pInternalEncoder;
+        /// <summary>
+        /// VFS data for file-based encoding.
+        /// </summary>
         public ma_encoder_vfs_data data;
 
+        /// <summary>
+        /// Sets the write callback for the encoder.
+        /// </summary>
+        /// <param name="callback">The write callback delegate.</param>
         public void SetWriteProc(ma_encoder_write_proc callback)
         {
             onWrite = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
 
+        /// <summary>
+        /// Sets the seek callback for the encoder.
+        /// </summary>
+        /// <param name="callback">The seek callback delegate.</param>
         public void SetSeekProc(ma_encoder_seek_proc callback)
         {
             onSeek = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
 
+        /// <summary>
+        /// Sets the init callback for the encoder.
+        /// </summary>
+        /// <param name="callback">The init callback delegate.</param>
         public void SetInitProc(ma_encoder_init_proc callback)
         {
             onInit = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
 
+        /// <summary>
+        /// Sets the uninit callback for the encoder.
+        /// </summary>
+        /// <param name="callback">The uninit callback delegate.</param>
         public void SetUninitProc(ma_encoder_uninit_proc callback)
         {
             onUninit = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
 
+        /// <summary>
+        /// Sets the write PCM frames callback for the encoder.
+        /// </summary>
+        /// <param name="callback">The write PCM frames callback delegate.</param>
         public void SetWritePCMFramesProc(ma_encoder_write_pcm_frames_proc callback)
         {
             onWritePCMFrames = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
 
+        /// <summary>
+        /// Union of VFS and file data for the encoder.
+        /// </summary>
         [StructLayout(LayoutKind.Explicit)]
         public struct ma_encoder_vfs_data
         {    
+            /// <summary>
+            /// Pointer to the virtual file system.
+            /// </summary>
             [FieldOffset(0)]
             public ma_vfs pVFS;    
             
+            /// <summary>
+            /// The VFS file handle.
+            /// </summary>
             [FieldOffset(0)]
             public ma_vfs_file file;
         }
     }
 
+    /// <summary>
+    /// Virtual table for a custom data source. Contains function pointers for read, seek, get data format, get cursor, get length, and set looping.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_data_source_vtable
     {
+        /// <summary>
+        /// Function pointer for reading PCM frames from the data source.
+        /// </summary>
         public IntPtr onRead;
+        /// <summary>
+        /// Function pointer for seeking within the data source.
+        /// </summary>
         public IntPtr onSeek;
+        /// <summary>
+        /// Function pointer for getting the data format of the data source.
+        /// </summary>
         public IntPtr onGetDataFormat;
+        /// <summary>
+        /// Function pointer for getting the current cursor position.
+        /// </summary>
         public IntPtr onGetCursor;
+        /// <summary>
+        /// Function pointer for getting the total length in PCM frames.
+        /// </summary>
         public IntPtr onGetLength;
+        /// <summary>
+        /// Function pointer for setting the looping state.
+        /// </summary>
         public IntPtr onSetLooping;
+        /// <summary>
+        /// Flags describing characteristics of the data source.
+        /// </summary>
         public ma_uint32 flags;
         
+        /// <summary>
+        /// Sets the read callback for the data source vtable.
+        /// </summary>
+        /// <param name="callback">The read callback delegate.</param>
         public void SetReadProc(ma_data_source_vtable_read_proc callback)
         {
             onRead = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
 
+        /// <summary>
+        /// Sets the seek callback for the data source vtable.
+        /// </summary>
+        /// <param name="callback">The seek callback delegate.</param>
         public void SetSeekProc(ma_data_source_vtable_seek_proc callback)
         {
             onSeek = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
 
+        /// <summary>
+        /// Sets the get data format callback for the data source vtable.
+        /// </summary>
+        /// <param name="callback">The get data format callback delegate.</param>
         public void SetGetDataFormatProc(ma_data_source_vtable_get_data_format_proc callback)
         {
             onGetDataFormat = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
 
+        /// <summary>
+        /// Sets the get cursor callback for the data source vtable.
+        /// </summary>
+        /// <param name="callback">The get cursor callback delegate.</param>
         public void SetGetCursorProc(ma_data_source_vtable_get_cursor_proc callback)
         {
             onGetCursor = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
 
+        /// <summary>
+        /// Sets the get length callback for the data source vtable.
+        /// </summary>
+        /// <param name="callback">The get length callback delegate.</param>
         public void SetGetLengthProc(ma_data_source_vtable_get_length_proc callback)
         {
             onGetLength = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
 
+        /// <summary>
+        /// Sets the set looping callback for the data source vtable.
+        /// </summary>
+        /// <param name="callback">The set looping callback delegate.</param>
         public void SetSetLoopingProc(ma_data_source_vtable_set_looping_proc callback)
         {
             onSetLooping = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
     }
 
+    /// <summary>
+    /// Configuration for a data source. Holds a pointer to the data source vtable.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_data_source_config
     {
+        /// <summary>
+        /// Pointer to the data source vtable.
+        /// </summary>
         public ma_data_source_vtable_ptr vtable;
     }
 
+    /// <summary>
+    /// Configuration for a data source node that wraps a data source as a node in the audio graph.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_data_source_node_config
     {
+        /// <summary>
+        /// The base node configuration.
+        /// </summary>
         public ma_node_config nodeConfig;
+        /// <summary>
+        /// Pointer to the data source to wrap.
+        /// </summary>
         public ma_data_source_ptr pDataSource;
     }
 
+    /// <summary>
+    /// Represents a data source node at runtime. Wraps a data source as a node in the audio graph.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_data_source_node
     {
+        /// <summary>
+        /// The base node.
+        /// </summary>
         public ma_node_base baseNode;
+        /// <summary>
+        /// Pointer to the wrapped data source.
+        /// </summary>
         public ma_data_source_ptr pDataSource;
     }
 
+    /// <summary>
+    /// Base structure for all data sources. Contains the vtable pointer, range and loop settings, and chaining support.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_data_source_base
     {
+        /// <summary>
+        /// Pointer to the data source vtable.
+        /// </summary>
         public IntPtr vtable;
+        /// <summary>
+        /// The beginning of the playback range in frames.
+        /// </summary>
         public ma_uint64 rangeBegInFrames;
+        /// <summary>
+        /// The end of the playback range in frames. Set to -1 for unranged (default).
+        /// </summary>
         public ma_uint64 rangeEndInFrames;             /* Set to -1 for unranged (default). */
+        /// <summary>
+        /// The loop start point relative to rangeBegInFrames.
+        /// </summary>
         public ma_uint64 loopBegInFrames;              /* Relative to rangeBegInFrames. */
+        /// <summary>
+        /// The loop end point relative to rangeBegInFrames. Set to -1 for the end of the range.
+        /// </summary>
         public ma_uint64 loopEndInFrames;              /* Relative to rangeBegInFrames. Set to -1 for the end of the range. */
+        /// <summary>
+        /// When non-NULL, the data source will act as a proxy and route all operations to pCurrent. Used in conjunction with pNext/onGetNext for seamless chaining.
+        /// </summary>
         public ma_data_source_ptr pCurrent;               /* When non-NULL, the data source being initialized will act as a proxy and will route all operations to pCurrent. Used in conjunction with pNext/onGetNext for seamless chaining. */
+        /// <summary>
+        /// The next data source in the chain. When set to NULL, onGetNext will be used.
+        /// </summary>
         public ma_data_source_ptr pNext;                  /* When set to NULL, onGetNext will be used. */
+        /// <summary>
+        /// Callback to determine the next data source. Will be used when pNext is NULL. If both are NULL, no next will be used.
+        /// </summary>
         public IntPtr onGetNext; /* Will be used when pNext is NULL. If both are NULL, no next will be used. */
+        /// <summary>
+        /// Whether looping is enabled.
+        /// </summary>
         public ma_bool32 isLooping;
 
+        /// <summary>
+        /// Sets the callback for determining the next data source in the chain.
+        /// </summary>
+        /// <param name="callback">The get next callback delegate.</param>
         public void SetNextProc(ma_data_source_get_next_proc callback)
         {
             onGetNext = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
     }
 
+    /// <summary>
+    /// Converts audio data between different channel configurations. Supports different mixing modes and channel maps.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_channel_converter
     {
+        /// <summary>
+        /// The sample format.
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The number of input channels.
+        /// </summary>
         public ma_uint32 channelsIn;
+        /// <summary>
+        /// The number of output channels.
+        /// </summary>
         public ma_uint32 channelsOut;
+        /// <summary>
+        /// The channel mixing mode.
+        /// </summary>
         public ma_channel_mix_mode mixingMode;
+        /// <summary>
+        /// The channel conversion path.
+        /// </summary>
         public ma_channel_conversion_path conversionPath;
+        /// <summary>
+        /// Pointer to the input channel map.
+        /// </summary>
         public ma_channel_ptr pChannelMapIn;
+        /// <summary>
+        /// Pointer to the output channel map.
+        /// </summary>
         public ma_channel_ptr pChannelMapOut;
+        /// <summary>
+        /// Pointer to the shuffle table, indexed by output channel index.
+        /// </summary>
         public IntPtr pShuffleTable;    /* Indexed by output channel index. */
+        /// <summary>
+        /// Channel mixing weights ([in][out]).
+        /// </summary>
         public ma_channel_converter_weights weights;  /* [in][out] */
         /* Memory management. */
+        /// <summary>
+        /// Heap allocation pointer.
+        /// </summary>
         public IntPtr _pHeap;
+        /// <summary>
+        /// Whether the converter owns the heap allocation.
+        /// </summary>
         public ma_bool32 _ownsHeap;
         
+        /// <summary>
+        /// Union of float and int16 weight arrays for the channel converter.
+        /// </summary>
         [StructLayout(LayoutKind.Explicit)]
         public struct ma_channel_converter_weights
         {
+            /// <summary>
+            /// Float weight array pointer (float**).
+            /// </summary>
             [FieldOffset(0)]
             public IntPtr f32;  // float**
+            /// <summary>
+            /// Int16 weight array pointer (ma_int32**).
+            /// </summary>
             [FieldOffset(0)]
             public IntPtr s16;  // ma_int32**
         }
     }
 
+    /// <summary>
+    /// Represents a biquad filter coefficient as a union of float and int32.
+    /// </summary>
     [StructLayout(LayoutKind.Explicit)]
     public struct ma_biquad_coefficient
     {
+        /// <summary>
+        /// The coefficient as a float value.
+        /// </summary>
         [FieldOffset(0)]
         public float f32;
+        /// <summary>
+        /// The coefficient as a signed 32-bit integer value.
+        /// </summary>
         [FieldOffset(0)]
         public UInt32 s32;
     }
 
+    /// <summary>
+    /// Configuration for a biquad filter. Specifies format, channels, and the six biquad coefficients (b0-b2, a0-a2).
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_biquad_config
     {
+        /// <summary>
+        /// The sample format.
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The number of channels.
+        /// </summary>
         public UInt32 channels;
+        /// <summary>
+        /// Feed-forward coefficient b0.
+        /// </summary>
         public double b0;
+        /// <summary>
+        /// Feed-forward coefficient b1.
+        /// </summary>
         public double b1;
+        /// <summary>
+        /// Feed-forward coefficient b2.
+        /// </summary>
         public double b2;
+        /// <summary>
+        /// Feed-back coefficient a0.
+        /// </summary>
         public double a0;
+        /// <summary>
+        /// Feed-back coefficient a1.
+        /// </summary>
         public double a1;
+        /// <summary>
+        /// Feed-back coefficient a2.
+        /// </summary>
         public double a2;
     }
 
+    /// <summary>
+    /// Represents a biquad filter at runtime with quantized coefficients and delay line state.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_biquad
     {
+        /// <summary>
+        /// The sample format.
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The number of channels.
+        /// </summary>
         public UInt32 channels;
+        /// <summary>
+        /// Quantized coefficient b0.
+        /// </summary>
         public ma_biquad_coefficient b0;
+        /// <summary>
+        /// Quantized coefficient b1.
+        /// </summary>
         public ma_biquad_coefficient b1;
+        /// <summary>
+        /// Quantized coefficient b2.
+        /// </summary>
         public ma_biquad_coefficient b2;
+        /// <summary>
+        /// Quantized coefficient a1.
+        /// </summary>
         public ma_biquad_coefficient a1;
+        /// <summary>
+        /// Quantized coefficient a2.
+        /// </summary>
         public ma_biquad_coefficient a2;
+        /// <summary>
+        /// Pointer to delay line state r1 (per channel).
+        /// </summary>
         public ma_biquad_coefficient_ptr pR1;
+        /// <summary>
+        /// Pointer to delay line state r2 (per channel).
+        /// </summary>
         public ma_biquad_coefficient_ptr pR2;
+        /// <summary>
+        /// Heap allocation pointer.
+        /// </summary>
         public IntPtr _pHeap;
+        /// <summary>
+        /// Whether the biquad owns the heap allocation.
+        /// </summary>
         public ma_bool32 _ownsHeap;
     }
 
+    /// <summary>
+    /// Configuration for a first-order low-pass filter.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_lpf1_config
     {
+        /// <summary>
+        /// The sample format.
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The number of channels.
+        /// </summary>
         public UInt32 channels;
+        /// <summary>
+        /// The sample rate.
+        /// </summary>
         public UInt32 sampleRate;
+        /// <summary>
+        /// The cutoff frequency in Hz.
+        /// </summary>
         public double cutoffFrequency;
+        /// <summary>
+        /// The quality factor.
+        /// </summary>
         public double q;
     }
 
+    /// <summary>
+    /// Configuration for a second-order low-pass filter.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_lpf2_config
     {
+        /// <summary>
+        /// The sample format.
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The number of channels.
+        /// </summary>
         public UInt32 channels;
+        /// <summary>
+        /// The sample rate.
+        /// </summary>
         public UInt32 sampleRate;
+        /// <summary>
+        /// The cutoff frequency in Hz.
+        /// </summary>
         public double cutoffFrequency;
+        /// <summary>
+        /// The quality factor.
+        /// </summary>
         public double q;
     }
 
+    /// <summary>
+    /// Represents a first-order low-pass filter at runtime.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_lpf1
     {
+        /// <summary>
+        /// The sample format.
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The number of channels.
+        /// </summary>
         public UInt32 channels;
+        /// <summary>
+        /// The filter coefficient.
+        /// </summary>
         public ma_biquad_coefficient a;
+        /// <summary>
+        /// Pointer to delay line state r1 (per channel).
+        /// </summary>
         public ma_biquad_coefficient_ptr pR1;
         /* Memory management. */
+        /// <summary>
+        /// Heap allocation pointer.
+        /// </summary>
         public IntPtr _pHeap;
+        /// <summary>
+        /// Whether the filter owns the heap allocation.
+        /// </summary>
         public ma_bool32 _ownsHeap;
     }
 
+    /// <summary>
+    /// Represents a second-order low-pass filter at runtime, implemented as a biquad filter.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_lpf2
     {
+        /// <summary>
+        /// The underlying biquad filter implementing the second-order low-pass.
+        /// </summary>
         public ma_biquad bq;   /* The second order low-pass filter is implemented as a biquad filter. */
     }
 
+    /// <summary>
+    /// Configuration for a configurable-order low-pass filter. Set order to 0 for passthrough.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_lpf_config
     {
+        /// <summary>
+        /// The sample format.
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The number of channels.
+        /// </summary>
         public UInt32 channels;
+        /// <summary>
+        /// The sample rate.
+        /// </summary>
         public UInt32 sampleRate;
+        /// <summary>
+        /// The cutoff frequency in Hz.
+        /// </summary>
         public double cutoffFrequency;
+        /// <summary>
+        /// The filter order. If set to 0, will be treated as a passthrough (no filtering will be applied).
+        /// </summary>
         public UInt32 order;    /* If set to 0, will be treated as a passthrough (no filtering will be applied). */
     }
 
+    /// <summary>
+    /// Represents a configurable-order low-pass filter at runtime. Composed of first and second-order stages.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_lpf
     {
+        /// <summary>
+        /// The sample format.
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The number of channels.
+        /// </summary>
         public UInt32 channels;
+        /// <summary>
+        /// The sample rate.
+        /// </summary>
         public UInt32 sampleRate;
+        /// <summary>
+        /// The number of first-order LPF stages.
+        /// </summary>
         public UInt32 lpf1Count;
+        /// <summary>
+        /// The number of second-order LPF stages.
+        /// </summary>
         public UInt32 lpf2Count;
+        /// <summary>
+        /// Pointer to the array of first-order LPF stages.
+        /// </summary>
         public ma_lpf1_ptr pLPF1;
+        /// <summary>
+        /// Pointer to the array of second-order LPF stages.
+        /// </summary>
         public ma_lpf2_ptr pLPF2;
         /* Memory management. */
+        /// <summary>
+        /// Heap allocation pointer.
+        /// </summary>
         public IntPtr _pHeap;
+        /// <summary>
+        /// Whether the filter owns the heap allocation.
+        /// </summary>
         public ma_bool32 _ownsHeap;
     }
 
+    /// <summary>
+    /// Configuration for a first-order high-pass filter.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_hpf1_config
     {
+        /// <summary>
+        /// The sample format.
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The number of channels.
+        /// </summary>
         public UInt32 channels;
+        /// <summary>
+        /// The sample rate.
+        /// </summary>
         public UInt32 sampleRate;
+        /// <summary>
+        /// The cutoff frequency in Hz.
+        /// </summary>
         public double cutoffFrequency;
+        /// <summary>
+        /// The quality factor.
+        /// </summary>
         public double q;
     }
 
+    /// <summary>
+    /// Configuration for a second-order high-pass filter.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_hpf2_config
     {
+        /// <summary>
+        /// The sample format.
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The number of channels.
+        /// </summary>
         public UInt32 channels;
+        /// <summary>
+        /// The sample rate.
+        /// </summary>
         public UInt32 sampleRate;
+        /// <summary>
+        /// The cutoff frequency in Hz.
+        /// </summary>
         public double cutoffFrequency;
+        /// <summary>
+        /// The quality factor.
+        /// </summary>
         public double q;
     }
     
+    /// <summary>
+    /// Represents a first-order high-pass filter at runtime.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_hpf1
     {
+        /// <summary>
+        /// The sample format.
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The number of channels.
+        /// </summary>
         public UInt32 channels;
+        /// <summary>
+        /// The filter coefficient.
+        /// </summary>
         public ma_biquad_coefficient a;
+        /// <summary>
+        /// Pointer to delay line state r1 (per channel).
+        /// </summary>
         public ma_biquad_coefficient_ptr pR1;
         /* Memory management. */
+        /// <summary>
+        /// Heap allocation pointer.
+        /// </summary>
         public IntPtr _pHeap;
+        /// <summary>
+        /// Whether the filter owns the heap allocation.
+        /// </summary>
         public ma_bool32 _ownsHeap;
     }
 
+    /// <summary>
+    /// Represents a second-order high-pass filter at runtime, implemented as a biquad filter.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_hpf2
     {
+        /// <summary>
+        /// The underlying biquad filter implementing the second-order high-pass.
+        /// </summary>
         public ma_biquad bq;   /* The second order high-pass filter is implemented as a biquad filter. */
     }
 
+    /// <summary>
+    /// Configuration for a configurable-order high-pass filter. Set order to 0 for passthrough.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_hpf_config
     {
+        /// <summary>
+        /// The sample format.
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The number of channels.
+        /// </summary>
         public UInt32 channels;
+        /// <summary>
+        /// The sample rate.
+        /// </summary>
         public UInt32 sampleRate;
+        /// <summary>
+        /// The cutoff frequency in Hz.
+        /// </summary>
         public double cutoffFrequency;
+        /// <summary>
+        /// The filter order. If set to 0, will be treated as a passthrough (no filtering will be applied).
+        /// </summary>
         public UInt32 order;    /* If set to 0, will be treated as a passthrough (no filtering will be applied). */
     }
 
+    /// <summary>
+    /// Represents a configurable-order high-pass filter at runtime. Composed of first and second-order stages.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_hpf
     {
+        /// <summary>
+        /// The sample format.
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The number of channels.
+        /// </summary>
         public UInt32 channels;
+        /// <summary>
+        /// The sample rate.
+        /// </summary>
         public UInt32 sampleRate;
+        /// <summary>
+        /// The number of first-order HPF stages.
+        /// </summary>
         public UInt32 hpf1Count;
+        /// <summary>
+        /// The number of second-order HPF stages.
+        /// </summary>
         public UInt32 hpf2Count;
+        /// <summary>
+        /// Pointer to the array of first-order HPF stages.
+        /// </summary>
         public ma_hpf1_ptr pHPF1;
+        /// <summary>
+        /// Pointer to the array of second-order HPF stages.
+        /// </summary>
         public ma_hpf2_ptr pHPF2;
         /* Memory management. */
+        /// <summary>
+        /// Heap allocation pointer.
+        /// </summary>
         public IntPtr _pHeap;
+        /// <summary>
+        /// Whether the filter owns the heap allocation.
+        /// </summary>
         public ma_bool32 _ownsHeap;
     }
 
+    /// <summary>
+    /// Configuration for a second-order band-pass filter.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_bpf2_config
     {
+        /// <summary>
+        /// The sample format.
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The number of channels.
+        /// </summary>
         public UInt32 channels;
+        /// <summary>
+        /// The sample rate.
+        /// </summary>
         public UInt32 sampleRate;
+        /// <summary>
+        /// The cutoff frequency in Hz.
+        /// </summary>
         public double cutoffFrequency;
+        /// <summary>
+        /// The quality factor.
+        /// </summary>
         public double q;
     }
 
+    /// <summary>
+    /// Represents a second-order band-pass filter at runtime, implemented as a biquad filter.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_bpf2
     {
+        /// <summary>
+        /// The underlying biquad filter implementing the second-order band-pass.
+        /// </summary>
         public ma_biquad bq;   /* The second order band-pass filter is implemented as a biquad filter. */
     }
 
+    /// <summary>
+    /// Configuration for a configurable-order band-pass filter. Set order to 0 for passthrough.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_bpf_config
     {
+        /// <summary>
+        /// The sample format.
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The number of channels.
+        /// </summary>
         public UInt32 channels;
+        /// <summary>
+        /// The sample rate.
+        /// </summary>
         public UInt32 sampleRate;
+        /// <summary>
+        /// The cutoff frequency in Hz.
+        /// </summary>
         public double cutoffFrequency;
+        /// <summary>
+        /// The filter order. If set to 0, will be treated as a passthrough (no filtering will be applied).
+        /// </summary>
         public UInt32 order;    /* If set to 0, will be treated as a passthrough (no filtering will be applied). */
     }
 
+    /// <summary>
+    /// Represents a configurable-order band-pass filter at runtime. Composed of second-order stages.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_bpf
     {
+        /// <summary>
+        /// The sample format.
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The number of channels.
+        /// </summary>
         public UInt32 channels;
+        /// <summary>
+        /// The number of second-order BPF stages.
+        /// </summary>
         public UInt32 bpf2Count;
+        /// <summary>
+        /// Pointer to the array of second-order BPF stages.
+        /// </summary>
         public ma_bpf2_ptr pBPF2;
         /* Memory management. */
+        /// <summary>
+        /// Heap allocation pointer.
+        /// </summary>
         public IntPtr _pHeap;
+        /// <summary>
+        /// Whether the filter owns the heap allocation.
+        /// </summary>
         public ma_bool32 _ownsHeap;
     }
     
+    /// <summary>
+    /// Configuration for a second-order notch (band-stop) filter.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_notch2_config
     {
+        /// <summary>
+        /// The sample format.
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The number of channels.
+        /// </summary>
         public UInt32 channels;
+        /// <summary>
+        /// The sample rate.
+        /// </summary>
         public UInt32 sampleRate;
+        /// <summary>
+        /// The quality factor.
+        /// </summary>
         public double q;
+        /// <summary>
+        /// The notch frequency in Hz.
+        /// </summary>
         public double frequency;
     }
 
+    /// <summary>
+    /// Configuration for a notch (band-stop) filter.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_notch_config
     {
+        /// <summary>
+        /// The sample format.
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The number of channels.
+        /// </summary>
         public UInt32 channels;
+        /// <summary>
+        /// The sample rate.
+        /// </summary>
         public UInt32 sampleRate;
+        /// <summary>
+        /// The quality factor.
+        /// </summary>
         public double q;
+        /// <summary>
+        /// The notch frequency in Hz.
+        /// </summary>
         public double frequency;
     }
 
+    /// <summary>
+    /// Represents a second-order notch filter at runtime, implemented as a biquad filter.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_notch2
     {
+        /// <summary>
+        /// The underlying biquad filter implementing the notch filter.
+        /// </summary>
         public ma_biquad bq;
     }
 
+    /// <summary>
+    /// Configuration for a second-order peaking EQ filter.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_peak2_config
     {
+        /// <summary>
+        /// The sample format.
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The number of channels.
+        /// </summary>
         public UInt32 channels;
+        /// <summary>
+        /// The sample rate.
+        /// </summary>
         public UInt32 sampleRate;
+        /// <summary>
+        /// The gain in decibels.
+        /// </summary>
         public double gainDB;
+        /// <summary>
+        /// The quality factor.
+        /// </summary>
         public double q;
+        /// <summary>
+        /// The peak frequency in Hz.
+        /// </summary>
         public double frequency;
     }
 
+    /// <summary>
+    /// Configuration for a peaking EQ filter.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_peak_config
     {
+        /// <summary>
+        /// The sample format.
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The number of channels.
+        /// </summary>
         public UInt32 channels;
+        /// <summary>
+        /// The sample rate.
+        /// </summary>
         public UInt32 sampleRate;
+        /// <summary>
+        /// The gain in decibels.
+        /// </summary>
         public double gainDB;
+        /// <summary>
+        /// The quality factor.
+        /// </summary>
         public double q;
+        /// <summary>
+        /// The peak frequency in Hz.
+        /// </summary>
         public double frequency;
     }
 
+    /// <summary>
+    /// Represents a second-order peaking EQ filter at runtime, implemented as a biquad filter.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_peak2
     {
+        /// <summary>
+        /// The underlying biquad filter implementing the peaking EQ.
+        /// </summary>
         public ma_biquad bq;
     }
 
+    /// <summary>
+    /// Configuration for a second-order low-shelf filter.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_loshelf2_config
     {
+        /// <summary>
+        /// The sample format.
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The number of channels.
+        /// </summary>
         public UInt32 channels;
+        /// <summary>
+        /// The sample rate.
+        /// </summary>
         public UInt32 sampleRate;
+        /// <summary>
+        /// The gain in decibels.
+        /// </summary>
         public double gainDB;
+        /// <summary>
+        /// The shelf slope.
+        /// </summary>
         public double shelfSlope;
+        /// <summary>
+        /// The shelf frequency in Hz.
+        /// </summary>
         public double frequency;
     }
 
+    /// <summary>
+    /// Configuration for a low-shelf filter.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_loshelf_config
     {
+        /// <summary>
+        /// The sample format.
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The number of channels.
+        /// </summary>
         public UInt32 channels;
+        /// <summary>
+        /// The sample rate.
+        /// </summary>
         public UInt32 sampleRate;
+        /// <summary>
+        /// The gain in decibels.
+        /// </summary>
         public double gainDB;
+        /// <summary>
+        /// The shelf slope.
+        /// </summary>
         public double shelfSlope;
+        /// <summary>
+        /// The shelf frequency in Hz.
+        /// </summary>
         public double frequency;
     }
 
+    /// <summary>
+    /// Represents a second-order low-shelf filter at runtime, implemented as a biquad filter.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_loshelf2
     {
+        /// <summary>
+        /// The underlying biquad filter implementing the low-shelf.
+        /// </summary>
         public ma_biquad bq;
     }
 
+    /// <summary>
+    /// Configuration for a second-order high-shelf filter.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_hishelf2_config
     {
+        /// <summary>
+        /// The sample format.
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The number of channels.
+        /// </summary>
         public UInt32 channels;
+        /// <summary>
+        /// The sample rate.
+        /// </summary>
         public UInt32 sampleRate;
+        /// <summary>
+        /// The gain in decibels.
+        /// </summary>
         public double gainDB;
+        /// <summary>
+        /// The shelf slope.
+        /// </summary>
         public double shelfSlope;
+        /// <summary>
+        /// The shelf frequency in Hz.
+        /// </summary>
         public double frequency;
     }
 
+    /// <summary>
+    /// Configuration for a high-shelf filter.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_hishelf_config
     {
+        /// <summary>
+        /// The sample format.
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The number of channels.
+        /// </summary>
         public UInt32 channels;
+        /// <summary>
+        /// The sample rate.
+        /// </summary>
         public UInt32 sampleRate;
+        /// <summary>
+        /// The gain in decibels.
+        /// </summary>
         public double gainDB;
+        /// <summary>
+        /// The shelf slope.
+        /// </summary>
         public double shelfSlope;
+        /// <summary>
+        /// The shelf frequency in Hz.
+        /// </summary>
         public double frequency;
     }
 
+    /// <summary>
+    /// Represents a second-order high-shelf filter at runtime, implemented as a biquad filter.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_hishelf2
     {
+        /// <summary>
+        /// The underlying biquad filter implementing the high-shelf.
+        /// </summary>
         public ma_biquad bq;
     }
 
+    /// <summary>
+    /// Configuration for a low-pass filter audio node.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_lpf_node_config
     {
+        /// <summary>
+        /// The base node configuration.
+        /// </summary>
         public ma_node_config nodeConfig;
+        /// <summary>
+        /// The low-pass filter configuration.
+        /// </summary>
         public ma_lpf_config lpf;
     }
 
+    /// <summary>
+    /// Runtime state for a low-pass filter audio node.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_lpf_node
     {
+        /// <summary>
+        /// The base node state.
+        /// </summary>
         public ma_node_base baseNode;
+        /// <summary>
+        /// The low-pass filter runtime state.
+        /// </summary>
         public ma_lpf lpf;
     }
 
+    /// <summary>
+    /// Configuration for a high-pass filter audio node.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_hpf_node_config
     {
+        /// <summary>
+        /// The base node configuration.
+        /// </summary>
         public ma_node_config nodeConfig;
+        /// <summary>
+        /// The high-pass filter configuration.
+        /// </summary>
         public ma_hpf_config hpf;
     }
 
+    /// <summary>
+    /// Runtime state for a high-pass filter audio node.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_hpf_node
     {
+        /// <summary>
+        /// The base node state.
+        /// </summary>
         public ma_node_base baseNode;
+        /// <summary>
+        /// The high-pass filter runtime state.
+        /// </summary>
         public ma_hpf hpf;
     }
 
+    /// <summary>
+    /// Configuration for a band-pass filter audio node.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_bpf_node_config
     {
+        /// <summary>
+        /// The base node configuration.
+        /// </summary>
         public ma_node_config nodeConfig;
+        /// <summary>
+        /// The band-pass filter configuration.
+        /// </summary>
         public ma_bpf_config bpf;
     }
 
+    /// <summary>
+    /// Runtime state for a band-pass filter audio node.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_bpf_node
     {
+        /// <summary>
+        /// The base node state.
+        /// </summary>
         public ma_node_base baseNode;
+        /// <summary>
+        /// The band-pass filter runtime state.
+        /// </summary>
         public ma_bpf bpf;
     }
 
+    /// <summary>
+    /// Configuration for a notch filter audio node.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_notch_node_config
     {
+        /// <summary>
+        /// The base node configuration.
+        /// </summary>
         public ma_node_config nodeConfig;
+        /// <summary>
+        /// The notch filter configuration.
+        /// </summary>
         public ma_notch_config notch;
     }
 
+    /// <summary>
+    /// Runtime state for a notch filter audio node.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_notch_node
     {
+        /// <summary>
+        /// The base node state.
+        /// </summary>
         public ma_node_base baseNode;
+        /// <summary>
+        /// The notch filter runtime state (order 2).
+        /// </summary>
         public ma_notch2 notch;
     }
 
+    /// <summary>
+    /// Configuration for a peaking EQ audio node.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_peak_node_config
     {
+        /// <summary>
+        /// The base node configuration.
+        /// </summary>
         public ma_node_config nodeConfig;
+        /// <summary>
+        /// The peaking EQ filter configuration.
+        /// </summary>
         public ma_peak_config peak;
     }
 
+    /// <summary>
+    /// Runtime state for a peaking EQ audio node.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_peak_node
     {
+        /// <summary>
+        /// The base node state.
+        /// </summary>
         public ma_node_base baseNode;
+        /// <summary>
+        /// The peaking EQ filter runtime state (order 2).
+        /// </summary>
         public ma_peak2 peak;
     }
 
+    /// <summary>
+    /// Configuration for a low-shelf filter audio node.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_loshelf_node_config
     {
+        /// <summary>
+        /// The base node configuration.
+        /// </summary>
         public ma_node_config nodeConfig;
+        /// <summary>
+        /// The low-shelf filter configuration.
+        /// </summary>
         public ma_loshelf_config loshelf;
     }
 
+    /// <summary>
+    /// Runtime state for a low-shelf filter audio node.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_loshelf_node
     {
+        /// <summary>
+        /// The base node state.
+        /// </summary>
         public ma_node_base baseNode;
+        /// <summary>
+        /// The low-shelf filter runtime state (order 2).
+        /// </summary>
         public ma_loshelf2 loshelf;
     }
 
+    /// <summary>
+    /// Configuration for a high-shelf filter audio node.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_hishelf_node_config
     {
+        /// <summary>
+        /// The base node configuration.
+        /// </summary>
         public ma_node_config nodeConfig;
+        /// <summary>
+        /// The high-shelf filter configuration.
+        /// </summary>
         public ma_hishelf_config hishelf;
     }
 
+    /// <summary>
+    /// Runtime state for a high-shelf filter audio node.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_hishelf_node
     {
+        /// <summary>
+        /// The base node state.
+        /// </summary>
         public ma_node_base baseNode;
+        /// <summary>
+        /// The high-shelf filter runtime state (order 2).
+        /// </summary>
         public ma_hishelf2 hishelf;
     }
 
+    /// <summary>
+    /// Configuration for a delay effect. Supports feedback decay for echo effects.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_delay_config
     {
+        /// <summary>
+        /// The number of audio channels.
+        /// </summary>
         public ma_uint32 channels;
+        /// <summary>
+        /// The sample rate in Hz.
+        /// </summary>
         public ma_uint32 sampleRate;
+        /// <summary>
+        /// The delay length in PCM frames.
+        /// </summary>
         public ma_uint32 delayInFrames;
+        /// <summary>
+        /// Set to true to delay the start of the output; false otherwise.
+        /// </summary>
         public ma_bool32 delayStart;       /* Set to true to delay the start of the output; false otherwise. */
+        /// <summary>
+        /// The wet (processed) signal level in the range 0..1. Default = 1.
+        /// </summary>
         public float wet;                  /* 0..1. Default = 1. */
+        /// <summary>
+        /// The dry (unprocessed) signal level in the range 0..1. Default = 1.
+        /// </summary>
         public float dry;                  /* 0..1. Default = 1. */
+        /// <summary>
+        /// Feedback decay in the range 0..1. Default = 0 (no feedback). Use this for echo.
+        /// </summary>
         public float decay;                /* 0..1. Default = 0 (no feedback). Feedback decay. Use this for echo. */
     }
 
+    /// <summary>
+    /// Runtime state for a delay effect.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_delay
     {
+        /// <summary>
+        /// The delay configuration.
+        /// </summary>
         public ma_delay_config config;
+        /// <summary>
+        /// Feedback is written to this cursor. Always equal or in front of the read cursor.
+        /// </summary>
         public ma_uint32 cursor;               /* Feedback is written to this cursor. Always equal or in front of the read cursor. */
+        /// <summary>
+        /// The size of the internal delay buffer in frames.
+        /// </summary>
         public ma_uint32 bufferSizeInFrames;
+        /// <summary>
+        /// Pointer to the internal delay buffer (interleaved float samples).
+        /// </summary>
         public IntPtr pBuffer;
     }
 
+    /// <summary>
+    /// Configuration for a delay effect audio node.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_delay_node_config
     {
+        /// <summary>
+        /// The base node configuration.
+        /// </summary>
         public ma_node_config nodeConfig;
+        /// <summary>
+        /// The delay effect configuration.
+        /// </summary>
         public ma_delay_config delay;
     }
 
+    /// <summary>
+    /// Runtime state for a delay effect audio node.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_delay_node
     {
+        /// <summary>
+        /// The base node state.
+        /// </summary>
         public ma_node_base baseNode;
+        /// <summary>
+        /// The delay effect runtime state.
+        /// </summary>
         public ma_delay delay;
     }
 
+    /// <summary>
+    /// Configuration for a splitter audio node. Takes 1 input bus and splits/copies it to multiple output buses.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_splitter_node_config
     {
+        /// <summary>
+        /// The base node configuration.
+        /// </summary>
         public ma_node_config nodeConfig;
+        /// <summary>
+        /// The number of audio channels.
+        /// </summary>
         public ma_uint32 channels;
+        /// <summary>
+        /// The number of output buses to split to.
+        /// </summary>
         public ma_uint32 outputBusCount;
     }
 
+    /// <summary>
+    /// Runtime state for a splitter audio node. 1 input bus, many output buses.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_splitter_node
     {
+        /// <summary>
+        /// The base node state.
+        /// </summary>
         public ma_node_base baseNode;
     }
 
+    /// <summary>
+    /// Configuration for a linear resampler. Provides low-quality but efficient sample rate conversion using linear interpolation.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_linear_resampler_config
     {
+        /// <summary>
+        /// The sample format.
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The number of audio channels.
+        /// </summary>
         public ma_uint32 channels;
+        /// <summary>
+        /// The input sample rate in Hz.
+        /// </summary>
         public ma_uint32 sampleRateIn;
+        /// <summary>
+        /// The output sample rate in Hz.
+        /// </summary>
         public ma_uint32 sampleRateOut;
+        /// <summary>
+        /// The low-pass filter order. Setting this to 0 will disable low-pass filtering.
+        /// </summary>
         public ma_uint32 lpfOrder;         /* The low-pass filter order. Setting this to 0 will disable low-pass filtering. */
+        /// <summary>
+        /// The low-pass filter Nyquist factor in the range 0..1. Defaults to 1.
+        /// 1 = Half the sampling frequency (Nyquist Frequency), 0.5 = Quarter the sampling frequency (half Nyquist Frequency), etc.
+        /// </summary>
         public double    lpfNyquistFactor; /* 0..1. Defaults to 1. 1 = Half the sampling frequency (Nyquist Frequency), 0.5 = Quarter the sampling frequency (half Nyquest Frequency), etc. */
     }
 
+    /// <summary>
+    /// Runtime state for a linear resampler.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_linear_resampler
     {
+        /// <summary>
+        /// The resampler configuration.
+        /// </summary>
         public ma_linear_resampler_config config;
+        /// <summary>
+        /// Integer part of the input advance per output frame.
+        /// </summary>
         public ma_uint32 inAdvanceInt;
+        /// <summary>
+        /// Fractional part of the input advance per output frame.
+        /// </summary>
         public ma_uint32 inAdvanceFrac;
+        /// <summary>
+        /// Integer part of the current input time position.
+        /// </summary>
         public ma_uint32 inTimeInt;
+        /// <summary>
+        /// Fractional part of the current input time position.
+        /// </summary>
         public ma_uint32 inTimeFrac;
+        /// <summary>
+        /// The previous input frame.
+        /// </summary>
         public ma_linear_resampler_data x0; /* The previous input frame. */
+        /// <summary>
+        /// The next input frame.
+        /// </summary>
         public ma_linear_resampler_data x1; /* The next input frame. */
+        /// <summary>
+        /// The low-pass filter used for anti-aliasing.
+        /// </summary>
         public ma_lpf lpf;
         /* Memory management. */
+        /// <summary>
+        /// Pointer to the internal heap memory.
+        /// </summary>
         public IntPtr _pHeap;
+        /// <summary>
+        /// Whether this resampler owns the heap allocation.
+        /// </summary>
         public ma_bool32 _ownsHeap;
 
+        /// <summary>
+        /// A sample frame in the resampler's internal buffer. Can represent f32 or s16 depending on format.
+        /// </summary>
         [StructLayout(LayoutKind.Explicit)]
         public struct ma_linear_resampler_data
         {
+            /// <summary>
+            /// Pointer to float samples.
+            /// </summary>
             [FieldOffset(0)]
             public IntPtr f32;
+            /// <summary>
+            /// Pointer to signed 16-bit integer samples.
+            /// </summary>
             [FieldOffset(0)]
             public IntPtr s16;
         }
     }
 
+    /// <summary>
+    /// Runtime state for a resampler. Supports swappable backends via a vtable.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_resampler
     {
+        /// <summary>
+        /// Pointer to the resampler backend instance.
+        /// </summary>
         public IntPtr pBackend;
+        /// <summary>
+        /// Pointer to the backend vtable (function pointers).
+        /// </summary>
         public IntPtr pBackendVTable;
+        /// <summary>
+        /// User data pointer for the backend.
+        /// </summary>
         public IntPtr pBackendUserData;
+        /// <summary>
+        /// The sample format.
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The number of audio channels.
+        /// </summary>
         public ma_uint32 channels;
+        /// <summary>
+        /// The input sample rate in Hz.
+        /// </summary>
         public ma_uint32 sampleRateIn;
+        /// <summary>
+        /// The output sample rate in Hz.
+        /// </summary>
         public ma_uint32 sampleRateOut;
+        /// <summary>
+        /// State for stock resamplers so we can avoid a malloc. For stock resamplers, pBackend will point here.
+        /// </summary>
         public ma_resampler_state state;    /* State for stock resamplers so we can avoid a malloc. For stock resamplers, pBackend will point here. */
         /* Memory management. */
+        /// <summary>
+        /// Pointer to the internal heap memory.
+        /// </summary>
         public IntPtr _pHeap;
+        /// <summary>
+        /// Whether this resampler owns the heap allocation.
+        /// </summary>
         public ma_bool32 _ownsHeap;
 
+        /// <summary>
+        /// Union of stock resampler state types. For the built-in linear resampler, this contains a ma_linear_resampler.
+        /// </summary>
         [StructLayout(LayoutKind.Explicit)]
         public struct ma_resampler_state
         {
+            /// <summary>
+            /// State for the built-in linear resampler.
+            /// </summary>
             [FieldOffset(0)]
             public ma_linear_resampler linear;
         }
     }
 
+    /// <summary>
+    /// Runtime state for a data converter. Wraps sample format conversion, channel conversion, and resampling in a single object.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_data_converter
     {
+        /// <summary>
+        /// The input sample format.
+        /// </summary>
         public ma_format formatIn;
+        /// <summary>
+        /// The output sample format.
+        /// </summary>
         public ma_format formatOut;
+        /// <summary>
+        /// The input channel count.
+        /// </summary>
         public ma_uint32 channelsIn;
+        /// <summary>
+        /// The output channel count.
+        /// </summary>
         public ma_uint32 channelsOut;
+        /// <summary>
+        /// The input sample rate in Hz.
+        /// </summary>
         public ma_uint32 sampleRateIn;
+        /// <summary>
+        /// The output sample rate in Hz.
+        /// </summary>
         public ma_uint32 sampleRateOut;
+        /// <summary>
+        /// The dithering mode to use during format conversion.
+        /// </summary>
         public ma_dither_mode ditherMode;
+        /// <summary>
+        /// The execution path the data converter will follow when processing.
+        /// </summary>
         public ma_data_converter_execution_path executionPath; /* The execution path the data converter will follow when processing. */
+        /// <summary>
+        /// The channel converter used for channel count conversion.
+        /// </summary>
         public ma_channel_converter channelConverter;
+        /// <summary>
+        /// The resampler used for sample rate conversion.
+        /// </summary>
         public ma_resampler resampler;
+        /// <summary>
+        /// Whether pre-format-conversion is needed.
+        /// </summary>
         public ma_bool8 hasPreFormatConversion;
+        /// <summary>
+        /// Whether post-format-conversion is needed.
+        /// </summary>
         public ma_bool8 hasPostFormatConversion;
+        /// <summary>
+        /// Whether channel conversion is needed.
+        /// </summary>
         public ma_bool8 hasChannelConverter;
+        /// <summary>
+        /// Whether resampling is needed.
+        /// </summary>
         public ma_bool8 hasResampler;
+        /// <summary>
+        /// Whether the data converter is in passthrough mode (no conversion needed).
+        /// </summary>
         public ma_bool8 isPassthrough;
         /* Memory management. */
+        /// <summary>
+        /// Whether this converter owns the heap allocation.
+        /// </summary>
         public ma_bool8 _ownsHeap;
+        /// <summary>
+        /// Pointer to the internal heap memory.
+        /// </summary>
         public IntPtr _pHeap;
     }
 
+    /// <summary>
+    /// Configuration for the resource manager. Manages asynchronous loading, decoding, and streaming of audio data sources.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_resource_manager_config
     {
+        /// <summary>
+        /// The allocation callbacks to use for memory management.
+        /// </summary>
         public ma_allocation_callbacks allocationCallbacks;
+        /// <summary>
+        /// Optional pointer to a log instance for diagnostic output.
+        /// </summary>
         public ma_log_ptr pLog;
+        /// <summary>
+        /// The decoded format to use. Set to ma_format_unknown (default) to use the file's native format.
+        /// </summary>
         public ma_format decodedFormat;        /* The decoded format to use. Set to ma_format_unknown (default) to use the file's native format. */
+        /// <summary>
+        /// The decoded channel count to use. Set to 0 (default) to use the file's native channel count.
+        /// </summary>
         public ma_uint32 decodedChannels;      /* The decoded channel count to use. Set to 0 (default) to use the file's native channel count. */
+        /// <summary>
+        /// The decoded sample rate to use. Set to 0 (default) to use the file's native sample rate.
+        /// </summary>
         public ma_uint32 decodedSampleRate;    /* the decoded sample rate to use. Set to 0 (default) to use the file's native sample rate. */
+        /// <summary>
+        /// The number of job threads. Set to 0 if you want to self-manage your job threads. Defaults to 1.
+        /// </summary>
         public ma_uint32 jobThreadCount;       /* Set to 0 if you want to self-manage your job threads. Defaults to 1. */
+        /// <summary>
+        /// The stack size for each job thread.
+        /// </summary>
         public size_t jobThreadStackSize;
+        /// <summary>
+        /// The maximum number of jobs that can fit in the queue at a time. Defaults to MA_JOB_TYPE_RESOURCE_MANAGER_QUEUE_CAPACITY. Cannot be zero.
+        /// </summary>
         public ma_uint32 jobQueueCapacity;     /* The maximum number of jobs that can fit in the queue at a time. Defaults to MA_JOB_TYPE_RESOURCE_MANAGER_QUEUE_CAPACITY. Cannot be zero. */
+        /// <summary>
+        /// Configuration flags for the resource manager.
+        /// </summary>
         public ma_uint32 flags;
+        /// <summary>
+        /// Optional virtual file system interface. Can be NULL in which case defaults will be used.
+        /// </summary>
         public ma_vfs_ptr pVFS;                   /* Can be NULL in which case defaults will be used. */
+        /// <summary>
+        /// Array of custom decoding backend vtable pointers for supporting additional file formats.
+        /// </summary>
         public IntPtr ppCustomDecodingBackendVTables;
+        /// <summary>
+        /// The number of custom decoding backend vtables.
+        /// </summary>
         public ma_uint32 customDecodingBackendCount;
+        /// <summary>
+        /// User data passed to custom decoding backends.
+        /// </summary>
         public IntPtr pCustomDecodingBackendUserData;
+        /// <summary>
+        /// The resampler configuration used when decoding sources.
+        /// </summary>
         public ma_resampler_config resampling;
 
         /// <summary>
@@ -2177,154 +5334,324 @@ namespace MiniAudioEx.Native
         }
     }
 
+    /// <summary>
+    /// Vtable for custom decoding backends. Each field is a function pointer for a decoding operation.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_decoding_backend_vtable
     {
+        /// <summary>
+        /// Function pointer for the onInit callback.
+        /// </summary>
         public IntPtr onInit;
+        /// <summary>
+        /// Function pointer for the onInitFile callback.
+        /// </summary>
         public IntPtr onInitFile;
+        /// <summary>
+        /// Function pointer for the onInitFileW (wide char) callback.
+        /// </summary>
         public IntPtr onInitFileW;
+        /// <summary>
+        /// Function pointer for the onInitMemory callback.
+        /// </summary>
         public IntPtr onInitMemory;
+        /// <summary>
+        /// Function pointer for the onUninit callback.
+        /// </summary>
         public IntPtr onUninit;
     }
 
+    /// <summary>
+    /// A simple fixed-size stack used internally by the node graph for pre-mix processing.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public unsafe struct ma_stack
     {
+        /// <summary>
+        /// Current offset into the stack data.
+        /// </summary>
         public size_t offset;
+        /// <summary>
+        /// Total size of the stack in bytes.
+        /// </summary>
         public size_t sizeInBytes;
+        /// <summary>
+        /// The stack data buffer (variable-length, fixed-size in C# representation).
+        /// </summary>
         public fixed byte _data[1];
     }
 
+    /// <summary>
+    /// Configuration for a node in the audio DSP graph.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_node_config
     {
+        /// <summary>
+        /// The node vtable. Should never be null. Initialization of the node will fail if null.
+        /// </summary>
         public ma_node_vtable_ptr vtable;          /* Should never be null. Initialization of the node will fail if so. */
+        /// <summary>
+        /// The initial playback state of the node. Defaults to ma_node_state_started.
+        /// </summary>
         public ma_node_state initialState;         /* Defaults to ma_node_state_started. */
+        /// <summary>
+        /// Only used if the vtable specifies an input bus count of MA_NODE_BUS_COUNT_UNKNOWN, otherwise must be set to MA_NODE_BUS_COUNT_UNKNOWN (default).
+        /// </summary>
         public ma_uint32 inputBusCount;            /* Only used if the vtable specifies an input bus count of `MA_NODE_BUS_COUNT_UNKNOWN`, otherwise must be set to `MA_NODE_BUS_COUNT_UNKNOWN` (default). */
+        /// <summary>
+        /// Only used if the vtable specifies an output bus count of MA_NODE_BUS_COUNT_UNKNOWN, otherwise must be set to MA_NODE_BUS_COUNT_UNKNOWN (default).
+        /// </summary>
         public ma_uint32 outputBusCount;           /* Only used if the vtable specifies an output bus count of `MA_NODE_BUS_COUNT_UNKNOWN`, otherwise  be set to `MA_NODE_BUS_COUNT_UNKNOWN` (default). */
+        /// <summary>
+        /// Channel counts per input bus. The number of elements is determined by the input bus count.
+        /// </summary>
         public IntPtr pInputChannels;          /* The number of elements are determined by the input bus count as determined by the vtable, or `inputBusCount` if the vtable specifies `MA_NODE_BUS_COUNT_UNKNOWN`. */
+        /// <summary>
+        /// Channel counts per output bus. The number of elements is determined by the output bus count.
+        /// </summary>
         public IntPtr pOutputChannels;         /* The number of elements are determined by the output bus count as determined by the vtable, or `outputBusCount` if the vtable specifies `MA_NODE_BUS_COUNT_UNKNOWN`. */
     }
 
+    /// <summary>
+    /// Vtable for a node in the audio graph. Contains the processing callback and configuration.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_node_vtable
     {
-        /*
-        Extended processing callback. This callback is used for effects that process input and output
-        at different rates (i.e. they perform resampling). This is similar to the simple version, only
-        they take two separate frame counts: one for input, and one for output.
-
-        On input, `pFrameCountOut` is equal to the capacity of the output buffer for each bus, whereas
-        `pFrameCountIn` will be equal to the number of PCM frames in each of the buffers in `ppFramesIn`.
-
-        On output, set `pFrameCountOut` to the number of PCM frames that were actually output and set
-        `pFrameCountIn` to the number of input frames that were consumed.
-        */
+        /// <summary>
+        /// Extended processing callback. Used for effects that process input and output at different rates (i.e. resampling).
+        /// On input, pFrameCountOut is the capacity of the output buffer; pFrameCountIn is the number of PCM frames in the input buffers.
+        /// On output, set pFrameCountOut to frames actually output and pFrameCountIn to frames consumed.
+        /// </summary>
         public IntPtr onProcess;
-
-        /*
-        A callback for retrieving the number of input frames that are required to output the
-        specified number of output frames. You would only want to implement this when the node performs
-        resampling. This is optional, even for nodes that perform resampling, but it does offer a
-        small reduction in latency as it allows miniaudio to calculate the exact number of input frames
-        to read at a time instead of having to estimate.
-        */
+        /// <summary>
+        /// Optional callback for retrieving the number of input frames required to output the specified number of output frames.
+        /// Useful for nodes that perform resampling to reduce latency.
+        /// </summary>
         public IntPtr onGetRequiredInputFrameCount;
-
-        /*
-        The number of input buses. This is how many sub-buffers will be contained in the `ppFramesIn`
-        parameters of the callbacks above.
-        */
+        /// <summary>
+        /// The number of input buses. This determines how many sub-buffers are contained in the processing callback's ppFramesIn.
+        /// </summary>
         public ma_uint8 inputBusCount;
-
-        /*
-        The number of output buses. This is how many sub-buffers will be contained in the `ppFramesOut`
-        parameters of the callbacks above.
-        */
+        /// <summary>
+        /// The number of output buses. This determines how many sub-buffers are contained in the processing callback's ppFramesOut.
+        /// </summary>
         public ma_uint8 outputBusCount;
-
-        /*
-        Flags describing characteristics of the node. This is currently just a placeholder for some
-        ideas for later on.
-        */
+        /// <summary>
+        /// Flags describing characteristics of the node.
+        /// </summary>
         public ma_node_flags flags;
 
+        /// <summary>
+        /// Sets the onProcess callback from a managed delegate.
+        /// </summary>
+        /// <param name="callback">The delegate to use as the processing callback.</param>
         public void SetOnProcess(ma_node_vtable_process_proc callback)
         {
             onProcess = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
 
+        /// <summary>
+        /// Sets the onGetRequiredInputFrameCount callback from a managed delegate.
+        /// </summary>
+        /// <param name="callback">The delegate to use as the input frame count callback.</param>
         public void SetOnGetRequiredInputFrameCount(ma_node_vtable_get_required_input_frame_count_proc callback)
         {
             onGetRequiredInputFrameCount = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
     }
 
+    /// <summary>
+    /// Represents an output bus of a node in the audio graph. An output bus is attached to an input bus as an item in a linked list.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_node_output_bus
     {
         /* Immutable. */
+        /// <summary>
+        /// The node that owns this output bus. Will be null for dummy head and tail nodes.
+        /// </summary>
         public ma_node_ptr pNode;                                         /* The node that owns this output bus. The input node. Will be null for dummy head and tail nodes. */
+        /// <summary>
+        /// The index of the output bus on the owning node.
+        /// </summary>
         public ma_uint8 outputBusIndex;                                /* The index of the output bus on pNode that this output bus represents. */
+        /// <summary>
+        /// The number of audio channels in this bus.
+        /// </summary>
         public ma_uint8 channels;                                      /* The number of channels in the audio stream for this bus. */
 
         /* Mutable via multiple threads. Must be used atomically. The weird ordering here is for packing reasons. */
+        /// <summary>
+        /// The index of the input bus on the connected input node. Required for detaching.
+        /// </summary>
         public ma_uint8 inputNodeInputBusIndex;                        /* The index of the input bus on the input. Required for detaching. Will only be used within the spinlock so does not need to be atomic. */
+        /// <summary>
+        /// State flags for tracking the read state of the output buffer. Combination of MA_NODE_OUTPUT_BUS_FLAG_*.
+        /// </summary>
         public ma_uint32 flags;                          /* Some state flags for tracking the read state of the output buffer. A combination of MA_NODE_OUTPUT_BUS_FLAG_*. */
+        /// <summary>
+        /// Reference count for thread safety when detaching.
+        /// </summary>
         public ma_uint32 refCount;                       /* Reference count for some thread-safety when detaching. */
+        /// <summary>
+        /// Prevents iteration of nodes that are in the middle of being detached. Used for thread safety.
+        /// </summary>
         public ma_bool32 isAttached;                     /* This is used to prevent iteration of nodes that are in the middle of being detached. Used for thread safety. */
+        /// <summary>
+        /// Spinlock for thread-safe attaching and detaching.
+        /// </summary>
         public ma_spinlock lck;                         /* Unfortunate lock, but significantly simplifies the implementation. Required for thread-safe attaching and detaching. */
+        /// <summary>
+        /// Linear volume of this output bus.
+        /// </summary>
         public float volume;                             /* Linear. */
+        /// <summary>
+        /// Pointer to the next output bus in the linked list. Null if tail node or detached.
+        /// </summary>
         public ma_node_output_bus_ptr pNext;    /* If null, it's the tail node or detached. */
+        /// <summary>
+        /// Pointer to the previous output bus in the linked list. Null if head node or detached.
+        /// </summary>
         public ma_node_output_bus_ptr pPrev;    /* If null, it's the head node or detached. */
+        /// <summary>
+        /// The node that this output bus is attached to. Required for detaching.
+        /// </summary>
         public ma_node_ptr pInputNode;          /* The node that this output bus is attached to. Required for detaching. */
     }
 
+    /// <summary>
+    /// Represents an input bus of a node. An input bus is essentially a linked list of output buses from other nodes.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_node_input_bus
     {
         /* Mutable via multiple threads. */
+        /// <summary>
+        /// Dummy head node for simplifying lock-free thread safety.
+        /// </summary>
         public ma_node_output_bus head;                /* Dummy head node for simplifying some lock-free thread-safety stuff. */
+        /// <summary>
+        /// Counter used to determine whether the input bus is finding the next node in the list. Used for thread safety when detaching.
+        /// </summary>
         public ma_uint32 nextCounter;    /* This is used to determine whether or not the input bus is finding the next node in the list. Used for thread safety when detaching output buses. */
+        /// <summary>
+        /// Spinlock for thread-safe attaching and detaching.
+        /// </summary>
         public ma_spinlock lck;         /* Unfortunate lock, but significantly simplifies the implementation. Required for thread-safe attaching and detaching. */
         /* Set once at startup. */
+        /// <summary>
+        /// The number of audio channels in this input bus.
+        /// </summary>
         public ma_uint8 channels;                      /* The number of channels in the audio stream for this bus. */
     }
 
+    /// <summary>
+    /// The base structure for all nodes in the audio graph. Contains common state, bus management, and timing information.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public unsafe struct ma_node_base
     {
         /* These variables are set once at startup. */
+        /// <summary>
+        /// The node graph this node belongs to.
+        /// </summary>
         public ma_node_graph_ptr pNodeGraph;                  /* The graph this node belongs to. */
+        /// <summary>
+        /// The node vtable pointer.
+        /// </summary>
         public ma_node_vtable_ptr vtable;
+        /// <summary>
+        /// The number of input buses.
+        /// </summary>
         public ma_uint32 inputBusCount;
+        /// <summary>
+        /// The number of output buses.
+        /// </summary>
         public ma_uint32 outputBusCount;
+        /// <summary>
+        /// Pointer to the array of input buses.
+        /// </summary>
         public ma_node_input_bus_ptr pInputBuses;
+        /// <summary>
+        /// Pointer to the array of output buses.
+        /// </summary>
         public ma_node_output_bus_ptr pOutputBuses;
+        /// <summary>
+        /// Cached input data allocated on the heap. Fixed size, per bus.
+        /// </summary>
         public IntPtr pCachedData;                         /* Allocated on the heap. Fixed size. Needs to be stored on the heap because reading from output buses is done in separate function calls. */
+        /// <summary>
+        /// The capacity of the input data cache in frames, per bus.
+        /// </summary>
         public ma_uint16 cachedDataCapInFramesPerBus;      /* The capacity of the input data cache in frames, per bus. */
 
         /* These variables are read and written only from the audio thread. */
+        /// <summary>
+        /// The number of cached output frames.
+        /// </summary>
         public ma_uint16 cachedFrameCountOut;
+        /// <summary>
+        /// The number of cached input frames.
+        /// </summary>
         public ma_uint16 cachedFrameCountIn;
+        /// <summary>
+        /// The number of input frames that have been consumed.
+        /// </summary>
         public ma_uint16 consumedFrameCountIn;
 
         /* These variables are read and written between different threads. */
+        /// <summary>
+        /// The playback state of the node. When stopped, nothing will be read.
+        /// </summary>
         public ma_node_state state;          /* When set to stopped, nothing will be read, regardless of the times in stateTimes. */
+        /// <summary>
+        /// Times (indexed by ma_node_state) at which the node should enter the given state, based on the global clock.
+        /// </summary>
         public fixed ma_uint64 stateTimes[2];      /* Indexed by ma_node_state. Specifies the time based on the global clock that a node should be considered to be in the relevant state. */
+        /// <summary>
+        /// The node's local clock. A running sum of output frames processed. Can be modified with ma_node_set_time().
+        /// </summary>
         public ma_uint64 localTime;          /* The node's local clock. This is just a running sum of the number of output frames that have been processed. Can be modified by any thread with `ma_node_set_time()`. */
 
         /* Memory management. */
+        /// <summary>
+        /// Inline array of input buses for local bus storage.
+        /// </summary>
         public ma_node_input_bus_array _inputBuses;
+        /// <summary>
+        /// Inline array of output buses for local bus storage.
+        /// </summary>
         public ma_node_output_bus_array _outputBuses;
+        /// <summary>
+        /// Heap allocation for internal use. pInputBuses/pOutputBuses point here if bus count exceeds MA_MAX_NODE_LOCAL_BUS_COUNT.
+        /// </summary>
         public IntPtr _pHeap;   /* A heap allocation for internal use only. pInputBuses and/or pOutputBuses will point to this if the bus count exceeds MA_MAX_NODE_LOCAL_BUS_COUNT. */
+        /// <summary>
+        /// If true, the node owns the heap allocation and _pHeap will be freed in ma_node_uninit().
+        /// </summary>
         public ma_bool32 _ownsHeap;    /* If set to true, the node owns the heap allocation and _pHeap will be freed in ma_node_uninit(). */
 
+        /// <summary>
+        /// Inline fixed-size array of input buses with indexer access.
+        /// </summary>
         [StructLayout(LayoutKind.Sequential)]
         public struct ma_node_input_bus_array
         {
+            /// <summary>
+            /// Bus at index 0.
+            /// </summary>
             public ma_node_input_bus b0;
+            /// <summary>
+            /// Bus at index 1.
+            /// </summary>
             public ma_node_input_bus b1;
+            /// <summary>
+            /// Gets the input bus at the specified index.
+            /// </summary>
+            /// <param name="index">The bus index (0 or 1).</param>
             public ref ma_node_input_bus this[int index]
             {
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -2342,11 +5669,24 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>
+        /// Inline fixed-size array of output buses with indexer access.
+        /// </summary>
         [StructLayout(LayoutKind.Sequential)]
         public struct ma_node_output_bus_array
         {
+            /// <summary>
+            /// Bus at index 0.
+            /// </summary>
             public ma_node_output_bus b0;
+            /// <summary>
+            /// Bus at index 1.
+            /// </summary>
             public ma_node_output_bus b1;
+            /// <summary>
+            /// Gets the output bus at the specified index.
+            /// </summary>
+            /// <param name="index">The bus index (0 or 1).</param>
             public ref ma_node_output_bus this[int index]
             {
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -2365,233 +5705,659 @@ namespace MiniAudioEx.Native
         }
     }
 
+    /// <summary>
+    /// Configuration for a node graph. Specifies channel count, processing buffer size, and stack memory.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_node_graph_config
     {
+        /// <summary>
+        /// The number of audio channels in the graph.
+        /// </summary>
         public ma_uint32 channels;
+        /// <summary>
+        /// The preferred processing size for node processing callbacks. Can be 0 to derive from the read request frame count.
+        /// </summary>
         public ma_uint32 processingSizeInFrames;   /* This is the preferred processing size for node processing callbacks unless overridden by a node itself. Can be 0 in which case it will be based on the frame count passed into ma_node_graph_read_pcm_frames(), but will not be well defined. */
+        /// <summary>
+        /// The size of the pre-mix stack in bytes. Defaults to 512KB per channel. Reducing saves memory but restricts graph depth.
+        /// </summary>
         public size_t preMixStackSizeInBytes;      /* Defaults to 512KB per channel. Reducing this will save memory, but the depth of your node graph will be more restricted. */
     }
 
+    /// <summary>
+    /// An audio DSP graph. The graph itself is a node so it can be connected as input to another graph.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_node_graph
     {
         /* Immutable. */
+        /// <summary>
+        /// The base node representing the graph itself. Has zero inputs; calls ma_node_graph_read_pcm_frames() to generate output.
+        /// </summary>
         public ma_node_base baseNode;                  /* The node graph itself is a node so it can be connected as an input to different node graph. This has zero inputs and calls ma_node_graph_read_pcm_frames() to generate it's output. */
+        /// <summary>
+        /// Special endpoint node that all nodes in the graph eventually connect to. Data is read from this node in ma_node_graph_read_pcm_frames().
+        /// </summary>
         public ma_node_base endpoint;              /* Special node that all nodes eventually connect to. Data is read from this node in ma_node_graph_read_pcm_frames(). */
+        /// <summary>
+        /// Processing cache buffer allocated when processingSizeInFrames is non-zero. Used for buffering variable frame count reads.
+        /// </summary>
         public IntPtr pProcessingCache;            /* This will be allocated when processingSizeInFrames is non-zero. This is needed because ma_node_graph_read_pcm_frames() can be called with a variable number of frames, and we may need to do some buffering in situations where the caller requests a frame count that's not a multiple of processingSizeInFrames. */
+        /// <summary>
+        /// Number of frames remaining in the processing cache.
+        /// </summary>
         public ma_uint32 processingCacheFramesRemaining;
+        /// <summary>
+        /// The processing size in frames.
+        /// </summary>
         public ma_uint32 processingSizeInFrames;
         /* Read and written by multiple threads. */
+        /// <summary>
+        /// Whether the graph is currently being read from.
+        /// </summary>
         public ma_bool32 isReading;
         /* Modified only by the audio thread. */
+        /// <summary>
+        /// Pointer to the pre-mix stack used during graph processing.
+        /// </summary>
         public ma_stack_ptr pPreMixStack;
     }
 
+    /// <summary>
+    /// Configuration for an effect node. Allows custom processing via a user-provided callback.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_effect_node_config
     {
+        /// <summary>
+        /// The sample rate in Hz.
+        /// </summary>
         public ma_uint32 sampleRate;
+        /// <summary>
+        /// The number of audio channels.
+        /// </summary>
         public ma_uint32 channels;
+        /// <summary>
+        /// Function pointer for the custom effect processing callback.
+        /// </summary>
         public IntPtr onProcess;
+        /// <summary>
+        /// User data pointer passed to the processing callback.
+        /// </summary>
         public IntPtr pUserData;
 
+        /// <summary>
+        /// Sets the onProcess callback from a managed delegate.
+        /// </summary>
+        /// <param name="callback">The delegate to use as the effect processing callback.</param>
         public void SetOnProcess(ma_effect_node_process_proc callback)
         {
             onProcess = MarshalHelper.GetFunctionPointerForDelegate(callback);
         }
     }
 
+    /// <summary>
+    /// Runtime state for an effect node. Wraps a user-defined effect within the audio graph.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_effect_node
     {
+        /// <summary>
+        /// The base node state.
+        /// </summary>
         public ma_node_base baseNode;
+        /// <summary>
+        /// The effect node configuration.
+        /// </summary>
         public ma_effect_node_config config;
     }
 
+    /// <summary>
+    /// Configuration for a gainer, which provides smooth volume transitions between old and new gain values.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_gainer_config
     {
+        /// <summary>
+        /// The number of audio channels.
+        /// </summary>
         public ma_uint32 channels;
+        /// <summary>
+        /// The number of frames over which gain changes are linearly interpolated.
+        /// </summary>
         public ma_uint32 smoothTimeInFrames;
     }
 
+    /// <summary>
+    /// Runtime state for a gainer. Used internally by the spatializer and can be used standalone for smooth volume changes.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_gainer
     {
+        /// <summary>
+        /// The gainer configuration.
+        /// </summary>
         public ma_gainer_config config;
+        /// <summary>
+        /// Current interpolation time in frames.
+        /// </summary>
         public ma_uint32 t;
+        /// <summary>
+        /// The master volume (linear).
+        /// </summary>
         public float masterVolume;
+        /// <summary>
+        /// Pointer to the old per-channel gain values.
+        /// </summary>
         public IntPtr pOldGains;
+        /// <summary>
+        /// Pointer to the new per-channel gain values.
+        /// </summary>
         public IntPtr pNewGains;
         /* Memory management. */
+        /// <summary>
+        /// Pointer to the internal heap memory.
+        /// </summary>
         public IntPtr _pHeap;
+        /// <summary>
+        /// Whether this gainer owns the heap allocation.
+        /// </summary>
         public ma_bool32 _ownsHeap;
     }
 
+    /// <summary>
+    /// Configuration for a spatializer, which applies 3D positioning, attenuation, and Doppler effect to audio.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_spatializer_config
     {
+        /// <summary>
+        /// The number of input channels.
+        /// </summary>
         public ma_uint32 channelsIn;
+        /// <summary>
+        /// The number of output channels.
+        /// </summary>
         public ma_uint32 channelsOut;
+        /// <summary>
+        /// Optional channel map for the input. Maps input channels to speaker positions for proper spatialization.
+        /// </summary>
         public ma_channel_ptr pChannelMapIn;
+        /// <summary>
+        /// The attenuation model to use (none, inverse, linear, exponential).
+        /// </summary>
         public ma_attenuation_model attenuationModel;
+        /// <summary>
+        /// The positioning algorithm to use.
+        /// </summary>
         public ma_positioning positioning;
+        /// <summary>
+        /// The coordinate system handedness. Defaults to right-handed. Forward is -Z in right-handed, +Z in left-handed.
+        /// </summary>
         public ma_handedness handedness;           /* Defaults to right. Forward is -1 on the Z axis. In a left handed system, forward is +1 on the Z axis. */
+        /// <summary>
+        /// The minimum gain applied by the spatializer.
+        /// </summary>
         public float minGain;
+        /// <summary>
+        /// The maximum gain applied by the spatializer.
+        /// </summary>
         public float maxGain;
+        /// <summary>
+        /// The distance at which the sound begins attenuating.
+        /// </summary>
         public float minDistance;
+        /// <summary>
+        /// The distance at which the sound reaches its minimum gain.
+        /// </summary>
         public float maxDistance;
+        /// <summary>
+        /// The rolloff factor controlling the shape of the attenuation curve.
+        /// </summary>
         public float rolloff;
+        /// <summary>
+        /// The inner cone angle in radians for directional audio.
+        /// </summary>
         public float coneInnerAngleInRadians;
+        /// <summary>
+        /// The outer cone angle in radians for directional audio.
+        /// </summary>
         public float coneOuterAngleInRadians;
+        /// <summary>
+        /// The gain applied outside the outer cone angle.
+        /// </summary>
         public float coneOuterGain;
+        /// <summary>
+        /// The Doppler effect factor. Set to 0 to disable Doppler effect.
+        /// </summary>
         public float dopplerFactor;                /* Set to 0 to disable doppler effect. */
+        /// <summary>
+        /// The directional attenuation factor. Set to 0 to disable directional attenuation.
+        /// </summary>
         public float directionalAttenuationFactor; /* Set to 0 to disable directional attenuation. */
+        /// <summary>
+        /// The minimal scaling factor for channel gains during spatialization. Range 0..1. Smaller values = more aggressive panning.
+        /// </summary>
         public float minSpatializationChannelGain; /* The minimal scaling factor to apply to channel gains when accounting for the direction of the sound relative to the listener. Must be in the range of 0..1. Smaller values means more aggressive directional panning, larger values means more subtle directional panning. */
+        /// <summary>
+        /// The number of frames over which gain changes are linearly interpolated.
+        /// </summary>
         public ma_uint32 gainSmoothTimeInFrames;   /* When the gain of a channel changes during spatialization, the transition will be linearly interpolated over this number of frames. */
     }
 
+    /// <summary>
+    /// Runtime state for a spatializer. Processes audio with 3D positioning relative to a listener.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_spatializer
     {
+        /// <summary>
+        /// The number of input channels.
+        /// </summary>
         public ma_uint32 channelsIn;
+        /// <summary>
+        /// The number of output channels.
+        /// </summary>
         public ma_uint32 channelsOut;
+        /// <summary>
+        /// Optional channel map for the input.
+        /// </summary>
         public ma_channel_ptr pChannelMapIn;
+        /// <summary>
+        /// The attenuation model.
+        /// </summary>
         public ma_attenuation_model attenuationModel;
+        /// <summary>
+        /// The positioning algorithm.
+        /// </summary>
         public ma_positioning positioning;
+        /// <summary>
+        /// The coordinate system handedness.
+        /// </summary>
         public ma_handedness handedness;           /* Defaults to right. Forward is -1 on the Z axis. In a left handed system, forward is +1 on the Z axis. */
+        /// <summary>
+        /// The minimum gain.
+        /// </summary>
         public float minGain;
+        /// <summary>
+        /// The maximum gain.
+        /// </summary>
         public float maxGain;
+        /// <summary>
+        /// The minimum distance for attenuation.
+        /// </summary>
         public float minDistance;
+        /// <summary>
+        /// The maximum distance for attenuation.
+        /// </summary>
         public float maxDistance;
+        /// <summary>
+        /// The rolloff factor.
+        /// </summary>
         public float rolloff;
+        /// <summary>
+        /// The inner cone angle in radians.
+        /// </summary>
         public float coneInnerAngleInRadians;
+        /// <summary>
+        /// The outer cone angle in radians.
+        /// </summary>
         public float coneOuterAngleInRadians;
+        /// <summary>
+        /// The gain outside the outer cone.
+        /// </summary>
         public float coneOuterGain;
+        /// <summary>
+        /// The Doppler factor. Set to 0 to disable.
+        /// </summary>
         public float dopplerFactor;                /* Set to 0 to disable doppler effect. */
+        /// <summary>
+        /// The directional attenuation factor. Set to 0 to disable.
+        /// </summary>
         public float directionalAttenuationFactor; /* Set to 0 to disable directional attenuation. */
+        /// <summary>
+        /// The number of frames for gain smoothing.
+        /// </summary>
         public ma_uint32 gainSmoothTimeInFrames;   /* When the gain of a channel changes during spatialization, the transition will be linearly interpolated over this number of frames. */
+        /// <summary>
+        /// The current 3D position of the sound source (thread-safe atomic).
+        /// </summary>
         public ma_atomic_vec3f position;
+        /// <summary>
+        /// The current 3D direction of the sound source (thread-safe atomic).
+        /// </summary>
         public ma_atomic_vec3f direction;
+        /// <summary>
+        /// The current 3D velocity of the sound source for Doppler effect (thread-safe atomic).
+        /// </summary>
         public ma_atomic_vec3f velocity;  /* For doppler effect. */
+        /// <summary>
+        /// The Doppler pitch factor computed during processing. Can be used by higher-level code for pitch shifting.
+        /// </summary>
         public float dopplerPitch; /* Will be updated by ma_spatializer_process_pcm_frames() and can be used by higher level functions to apply a pitch shift for doppler effect. */
+        /// <summary>
+        /// The minimal spatialization channel gain.
+        /// </summary>
         public float minSpatializationChannelGain;
+        /// <summary>
+        /// Internal gainer used for smooth gain transitions.
+        /// </summary>
         public ma_gainer gainer;   /* For smooth gain transitions. */
+        /// <summary>
+        /// Buffer for storing new channel gains during processing. Heap-allocated, offset of _pHeap.
+        /// </summary>
         public IntPtr pNewChannelGainsOut; /* An offset of _pHeap. Used by ma_spatializer_process_pcm_frames() to store new channel gains. The number of elements in this array is equal to config.channelsOut. */
         /* Memory management. */
+        /// <summary>
+        /// Pointer to the internal heap memory.
+        /// </summary>
         public IntPtr _pHeap;
+        /// <summary>
+        /// Whether this spatializer owns the heap allocation.
+        /// </summary>
         public ma_bool32 _ownsHeap;
     }
 
+    /// <summary>
+    /// Configuration for a spatializer listener. Defines the listener's output setup and world parameters.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_spatializer_listener_config
     {
+        /// <summary>
+        /// The number of output channels for the listener.
+        /// </summary>
         public ma_uint32 channelsOut;
+        /// <summary>
+        /// Optional channel map for the output. Maps output channels to speaker positions.
+        /// </summary>
         public ma_channel_ptr pChannelMapOut;
+        /// <summary>
+        /// The coordinate system handedness. Defaults to right-handed.
+        /// </summary>
         public ma_handedness handedness;   /* Defaults to right. Forward is -1 on the Z axis. In a left handed system, forward is +1 on the Z axis. */
+        /// <summary>
+        /// The inner cone angle of the listener in radians.
+        /// </summary>
         public float coneInnerAngleInRadians;
+        /// <summary>
+        /// The outer cone angle of the listener in radians.
+        /// </summary>
         public float coneOuterAngleInRadians;
+        /// <summary>
+        /// The gain applied outside the outer cone.
+        /// </summary>
         public float coneOuterGain;
+        /// <summary>
+        /// The speed of sound used for Doppler effect calculations.
+        /// </summary>
         public float speedOfSound;
+        /// <summary>
+        /// The world up vector (e.g. (0, 1, 0) for Y-up).
+        /// </summary>
         public ma_vec3f worldUp;
     }
 
+    /// <summary>
+    /// Runtime state for a spatializer listener. Represents the listener's position, direction, and velocity in 3D space.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_spatializer_listener
     {
+        /// <summary>
+        /// The listener configuration.
+        /// </summary>
         public ma_spatializer_listener_config config;
+        /// <summary>
+        /// The absolute 3D position of the listener (thread-safe atomic).
+        /// </summary>
         public ma_atomic_vec3f position;  /* The absolute position of the listener. */
+        /// <summary>
+        /// The direction the listener is facing. The world up vector is defined in config.worldUp (thread-safe atomic).
+        /// </summary>
         public ma_atomic_vec3f direction; /* The direction the listener is facing. The world up vector is config.worldUp. */
+        /// <summary>
+        /// The velocity of the listener for Doppler effect (thread-safe atomic).
+        /// </summary>
         public ma_atomic_vec3f velocity;
+        /// <summary>
+        /// Whether the listener is enabled for spatialization.
+        /// </summary>
         public ma_bool32 isEnabled;
         /* Memory management. */
+        /// <summary>
+        /// Whether this listener owns the heap allocation.
+        /// </summary>
         public ma_bool32 _ownsHeap;
+        /// <summary>
+        /// Pointer to the internal heap memory.
+        /// </summary>
         public IntPtr _pHeap;
     }
 
+    /// <summary>
+    /// Configuration for a waveform generator data source. Produces sine, square, triangle, and sawtooth waves.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_waveform_config
     {
+        /// <summary>
+        /// The output sample format.
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The number of output channels.
+        /// </summary>
         public ma_uint32 channels;
+        /// <summary>
+        /// The sample rate in Hz.
+        /// </summary>
         public ma_uint32 sampleRate;
+        /// <summary>
+        /// The type of waveform to generate.
+        /// </summary>
         public ma_waveform_type type;
+        /// <summary>
+        /// The amplitude of the waveform.
+        /// </summary>
         public double amplitude;
+        /// <summary>
+        /// The frequency of the waveform in Hz.
+        /// </summary>
         public double frequency;
     }
 
+    /// <summary>
+    /// Runtime state for a waveform generator. Extends ma_data_source_base as a data source.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_waveform
     {
+        /// <summary>
+        /// The base data source state.
+        /// </summary>
         public ma_data_source_base ds;
+        /// <summary>
+        /// The waveform configuration.
+        /// </summary>
         public ma_waveform_config config;
+        /// <summary>
+        /// The phase advance per output frame.
+        /// </summary>
         public double advance;
+        /// <summary>
+        /// The current phase time in seconds.
+        /// </summary>
         public double time;
     }
 
+    /// <summary>
+    /// Configuration for a pulse wave generator. Produces a rectangular pulse with a configurable duty cycle.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_pulsewave_config
     {
+        /// <summary>
+        /// The output sample format.
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The number of output channels.
+        /// </summary>
         public ma_uint32 channels;
+        /// <summary>
+        /// The sample rate in Hz.
+        /// </summary>
         public ma_uint32 sampleRate;
+        /// <summary>
+        /// The duty cycle of the pulse wave in the range 0..1.
+        /// </summary>
         public double dutyCycle;
+        /// <summary>
+        /// The amplitude of the pulse wave.
+        /// </summary>
         public double amplitude;
+        /// <summary>
+        /// The frequency in Hz.
+        /// </summary>
         public double frequency;
     }
 
+    /// <summary>
+    /// Runtime state for a pulse wave generator. Internally uses a ma_waveform for the underlying oscillation.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_pulsewave
     {
+        /// <summary>
+        /// The underlying waveform used for oscillation.
+        /// </summary>
         public ma_waveform waveform;
+        /// <summary>
+        /// The pulse wave configuration.
+        /// </summary>
         public ma_pulsewave_config config;
     }
 
+    /// <summary>
+    /// Configuration for a noise generator data source. Produces white, pink, or brownian noise.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_noise_config
     {
+        /// <summary>
+        /// The output sample format.
+        /// </summary>
         public ma_format format;
+        /// <summary>
+        /// The number of output channels.
+        /// </summary>
         public ma_uint32 channels;
+        /// <summary>
+        /// The type of noise to generate (white, pink, or brownian).
+        /// </summary>
         public ma_noise_type type;
+        /// <summary>
+        /// The seed for the random number generator.
+        /// </summary>
         public ma_int32 seed;
+        /// <summary>
+        /// The amplitude of the noise.
+        /// </summary>
         public double amplitude;
+        /// <summary>
+        /// Whether to duplicate the same noise across all channels. If false, each channel gets independent noise.
+        /// </summary>
         public ma_bool32 duplicateChannels;
     }
 
+    /// <summary>
+    /// A simple linear congruential generator (LCG) used for pseudo-random number generation in the noise generator.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_lcg
     {
+        /// <summary>
+        /// The current LCG state.
+        /// </summary>
         public ma_uint32 state;
     }
 
+    /// <summary>
+    /// Runtime state for a noise generator. Extends ma_data_source_base as a data source. Supports white, pink, and brownian noise.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ma_noise
     {
+        /// <summary>
+        /// The base data source state.
+        /// </summary>
         ma_data_source_base ds;
+        /// <summary>
+        /// The noise generator configuration.
+        /// </summary>
         ma_noise_config config;
+        /// <summary>
+        /// The linear congruential generator for pseudo-random numbers.
+        /// </summary>
         ma_lcg lcg;
+        /// <summary>
+        /// The noise state union (pink or brownian, depending on noise type).
+        /// </summary>
         State state;
         /* Memory management. */
+        /// <summary>
+        /// Pointer to the internal heap memory.
+        /// </summary>
         IntPtr _pHeap;
+        /// <summary>
+        /// Whether this noise generator owns the heap allocation.
+        /// </summary>
         ma_bool32 _ownsHeap;
 
+        /// <summary>
+        /// Union of noise state types. Either pink noise or brownian noise state, depending on configuration.
+        /// </summary>
         [StructLayout(LayoutKind.Explicit)]
         public struct State
         {
+            /// <summary>
+            /// Pink noise state (Voss-McCartney algorithm).
+            /// </summary>
             [FieldOffset(0)]
             public Pink pink;
+            /// <summary>
+            /// Brownian noise state (integrated white noise).
+            /// </summary>
             [FieldOffset(0)]
             public Brownian brownian;
+
+            /// <summary>
+            /// State for pink noise generation using the Voss-McCartney algorithm. Contains frequency bins and accumulation buffers.
+            /// </summary>
             [StructLayout(LayoutKind.Sequential)]
             public struct Pink
             {
+                /// <summary>
+                /// Pointer to the frequency bin array.
+                /// </summary>
                 public IntPtr bin;
+                /// <summary>
+                /// Pointer to the per-channel accumulation values.
+                /// </summary>
                 public IntPtr accumulation;
             }
+
+            /// <summary>
+            /// State for brownian noise generation. Integrates white noise for a random walk effect.
+            /// </summary>
             [StructLayout(LayoutKind.Sequential)]
             public struct Brownian
             {
+                /// <summary>
+                /// Pointer to the per-channel accumulation values.
+                /// </summary>
                 public IntPtr accumulation;
             }
         }

--- a/src/Native/NativeArray.cs
+++ b/src/Native/NativeArray.cs
@@ -50,12 +50,23 @@ using System;
 
 namespace MiniAudioEx.Native
 {
+    /// <summary>
+    /// Provides a view over a contiguous block of native memory as a typed, indexable span.
+    /// This is a <c>ref struct</c> that cannot be allocated on the managed heap and is intended
+    /// for short-lived access to native arrays returned by miniaudio interop functions.
+    /// </summary>
+    /// <typeparam name="T">The unmanaged type of elements stored in the native array.</typeparam>
     public unsafe ref struct NativeArray<T> where T : unmanaged
     {
+        /// <summary>
+        /// A native pointer to the first element of the array. The caller is responsible for
+        /// ensuring the memory remains valid during the lifetime of this wrapper.
+        /// </summary>
         internal void* _pointer;
         /// <summary>The number of elements this NativeArray contains.</summary>
         private readonly int _length;
 
+        /// <summary>Gets the number of elements in this <see cref="NativeArray{T}"/>.</summary>
         public int Length
         {
             get
@@ -64,6 +75,7 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>Gets a value indicating whether this <see cref="NativeArray{T}"/> is empty.</summary>
         public bool IsEmpty
         {
             get
@@ -72,6 +84,7 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>Gets an <see cref="IntPtr"/> pointing to the first element of the array.</summary>
         public IntPtr Pointer
         {
             get
@@ -80,6 +93,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>Gets a reference to the element at the specified index.</summary>
+        /// <param name="index">The zero-based index of the element to get.</param>
+        /// <returns>A reference to the element at the specified index.</returns>
         public ref T this[int index]
         {
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
@@ -91,6 +107,9 @@ namespace MiniAudioEx.Native
             }
         }
 
+        /// <summary>Initializes a new instance of the <see cref="NativeArray{T}"/> struct from a native pointer.</summary>
+        /// <param name="pointer">A pointer to the first element of the array.</param>
+        /// <param name="length">The number of elements in the array.</param>
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public NativeArray(void* pointer, int length)
         {
@@ -98,6 +117,9 @@ namespace MiniAudioEx.Native
             _length = length;
         }
 
+        /// <summary>Initializes a new instance of the <see cref="NativeArray{T}"/> struct from an <see cref="IntPtr"/>.</summary>
+        /// <param name="pointer">An <see cref="IntPtr"/> pointing to the first element of the array.</param>
+        /// <param name="length">The number of elements in the array.</param>
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public NativeArray(System.IntPtr pointer, int length)
         {
@@ -105,6 +127,9 @@ namespace MiniAudioEx.Native
             _length = length;
         }
 
+        /// <summary>Copies the contents of this <see cref="NativeArray{T}"/> to the specified destination array.</summary>
+        /// <param name="destination">The destination <see cref="NativeArray{T}"/> to copy the elements to.</param>
+        /// <exception cref="ArgumentException">Thrown when the destination array is shorter than this array.</exception>
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void CopyTo(NativeArray<T> destination)
         {


### PR DESCRIPTION
…espace except for MiniAudioExNative.cs. The work was done using AI, without altering any existing code (including original comments). Only documentation comments were added on top of the original code. Preliminary checks passed. The original MiniAudio project was used as a reference; members that were uncertain were left without documentation comments.